### PR TITLE
Move to double to eliminate compile warnings.

### DIFF
--- a/src/example/MainWindow.cpp
+++ b/src/example/MainWindow.cpp
@@ -83,7 +83,7 @@ MainWindow::MainWindow( QWidget *parent ) :
 
 MainWindow::~MainWindow()
 {
-    cout << "Average time step: " << ( (double)m_realTime ) / ( (double)m_steps ) << " s" << endl;
+    cout << "Average time step: " << ( static_cast<double>(m_realTime) ) / ( static_cast<double>(m_steps) ) << " s" << endl;
 
     if ( m_timerId ) killTimer( m_timerId );
 
@@ -138,41 +138,41 @@ void MainWindow::timerEvent( QTimerEvent *event )
         adf       = -360.0f * sin( m_realTime /  50.0f );
         dme       =   99.0f * sin( m_realTime / 100.0f );
 
-        m_ui->spinBoxAlpha ->setValue( alpha     );
-        m_ui->spinBoxBeta  ->setValue( beta      );
-        m_ui->spinBoxRoll  ->setValue( roll      );
-        m_ui->spinBoxPitch ->setValue( pitch     );
-        m_ui->spinBoxSlip  ->setValue( slipSkid  );
-        m_ui->spinBoxTurn  ->setValue( turnRate  );
-        m_ui->spinBoxDevH  ->setValue( devH      );
-        m_ui->spinBoxDevV  ->setValue( devV      );
-        m_ui->spinBoxHead  ->setValue( heading   );
-        m_ui->spinBoxSpeed ->setValue( airspeed  );
-        m_ui->spinBoxMach  ->setValue( machNo    );
-        m_ui->spinBoxAlt   ->setValue( altitude  );
-        m_ui->spinBoxPress ->setValue( pressure  );
-        m_ui->spinBoxClimb ->setValue( climbRate );
-        m_ui->spinBoxADF   ->setValue( adf       );
-        m_ui->spinBoxDME   ->setValue( dme       );
+        m_ui->spinBoxAlpha->setValue( alpha     );
+        m_ui->spinBoxBeta->setValue( beta      );
+        m_ui->spinBoxRoll->setValue( roll      );
+        m_ui->spinBoxPitch->setValue( pitch     );
+        m_ui->spinBoxSlip->setValue( slipSkid  );
+        m_ui->spinBoxTurn->setValue( turnRate  );
+        m_ui->spinBoxDevH->setValue( devH      );
+        m_ui->spinBoxDevV->setValue( devV      );
+        m_ui->spinBoxHead->setValue( heading   );
+        m_ui->spinBoxSpeed->setValue( airspeed  );
+        m_ui->spinBoxMach->setValue( machNo    );
+        m_ui->spinBoxAlt->setValue( altitude  );
+        m_ui->spinBoxPress->setValue( pressure  );
+        m_ui->spinBoxClimb->setValue( climbRate );
+        m_ui->spinBoxADF->setValue( adf       );
+        m_ui->spinBoxDME->setValue( dme       );
     }
     else
     {
-        alpha     = (double)m_ui->spinBoxAlpha ->value();
-        beta      = (double)m_ui->spinBoxBeta  ->value();
-        roll      = (double)m_ui->spinBoxRoll  ->value();
-        pitch     = (double)m_ui->spinBoxPitch ->value();
-        heading   = (double)m_ui->spinBoxHead  ->value();
-        slipSkid  = (double)m_ui->spinBoxSlip  ->value();
-        turnRate  = (double)m_ui->spinBoxTurn  ->value();
-        devH      = (double)m_ui->spinBoxDevH  ->value();
-        devV      = (double)m_ui->spinBoxDevV  ->value();
-        airspeed  = (double)m_ui->spinBoxSpeed ->value();
-        pressure  = (double)m_ui->spinBoxPress ->value();
-        altitude  = (double)m_ui->spinBoxAlt   ->value();
-        climbRate = (double)m_ui->spinBoxClimb ->value();
-        machNo    = (double)m_ui->spinBoxMach  ->value();
-        adf       = (double)m_ui->spinBoxADF   ->value();
-        dme       = (double)m_ui->spinBoxDME   ->value();
+        alpha     = static_cast<double>(m_ui->spinBoxAlpha->value());
+        beta      = static_cast<double>(m_ui->spinBoxBeta->value());
+        roll      = static_cast<double>(m_ui->spinBoxRoll->value());
+        pitch     = static_cast<double>(m_ui->spinBoxPitch->value());
+        heading   = static_cast<double>(m_ui->spinBoxHead->value());
+        slipSkid  = static_cast<double>(m_ui->spinBoxSlip->value());
+        turnRate  = static_cast<double>(m_ui->spinBoxTurn->value());
+        devH      = static_cast<double>(m_ui->spinBoxDevH->value());
+        devV      = static_cast<double>(m_ui->spinBoxDevV->value());
+        airspeed  = static_cast<double>(m_ui->spinBoxSpeed->value());
+        pressure  = static_cast<double>(m_ui->spinBoxPress->value());
+        altitude  = static_cast<double>(m_ui->spinBoxAlt->value());
+        climbRate = static_cast<double>(m_ui->spinBoxClimb->value());
+        machNo    = static_cast<double>(m_ui->spinBoxMach->value());
+        adf       = static_cast<double>(m_ui->spinBoxADF->value());
+        dme       = static_cast<double>(m_ui->spinBoxDME->value());
     }
 
     m_ui->widgetPFD->setFlightPathMarker ( alpha, beta );

--- a/src/example/MainWindow.cpp
+++ b/src/example/MainWindow.cpp
@@ -98,26 +98,26 @@ void MainWindow::timerEvent( QTimerEvent *event )
     QMainWindow::timerEvent( event );
     /////////////////////////////////
 
-    float timeStep = m_time.restart();
+    double timeStep = m_time.restart();
 
     m_realTime = m_realTime + timeStep / 1000.0f;
 
-    float alpha     =  0.0f;
-    float beta      =  0.0f;
-    float roll      =  0.0f;
-    float pitch     =  0.0f;
-    float heading   =  0.0f;
-    float slipSkid  =  0.0f;
-    float turnRate  =  0.0f;
-    float devH      =  0.0f;
-    float devV      =  0.0f;
-    float airspeed  =  0.0f;
-    float altitude  =  0.0f;
-    float pressure  = 28.0f;
-    float climbRate =  0.0f;
-    float machNo    =  0.0f;
-    float adf       =  0.0f;
-    float dme       =  0.0f;
+    double alpha     =  0.0f;
+    double beta      =  0.0f;
+    double roll      =  0.0f;
+    double pitch     =  0.0f;
+    double heading   =  0.0f;
+    double slipSkid  =  0.0f;
+    double turnRate  =  0.0f;
+    double devH      =  0.0f;
+    double devV      =  0.0f;
+    double airspeed  =  0.0f;
+    double altitude  =  0.0f;
+    double pressure  = 28.0f;
+    double climbRate =  0.0f;
+    double machNo    =  0.0f;
+    double adf       =  0.0f;
+    double dme       =  0.0f;
 
     if ( m_ui->pushButtonAuto->isChecked() )
     {
@@ -157,22 +157,22 @@ void MainWindow::timerEvent( QTimerEvent *event )
     }
     else
     {
-        alpha     = (float)m_ui->spinBoxAlpha ->value();
-        beta      = (float)m_ui->spinBoxBeta  ->value();
-        roll      = (float)m_ui->spinBoxRoll  ->value();
-        pitch     = (float)m_ui->spinBoxPitch ->value();
-        heading   = (float)m_ui->spinBoxHead  ->value();
-        slipSkid  = (float)m_ui->spinBoxSlip  ->value();
-        turnRate  = (float)m_ui->spinBoxTurn  ->value();
-        devH      = (float)m_ui->spinBoxDevH  ->value();
-        devV      = (float)m_ui->spinBoxDevV  ->value();
-        airspeed  = (float)m_ui->spinBoxSpeed ->value();
-        pressure  = (float)m_ui->spinBoxPress ->value();
-        altitude  = (float)m_ui->spinBoxAlt   ->value();
-        climbRate = (float)m_ui->spinBoxClimb ->value();
-        machNo    = (float)m_ui->spinBoxMach  ->value();
-        adf       = (float)m_ui->spinBoxADF   ->value();
-        dme       = (float)m_ui->spinBoxDME   ->value();
+        alpha     = (double)m_ui->spinBoxAlpha ->value();
+        beta      = (double)m_ui->spinBoxBeta  ->value();
+        roll      = (double)m_ui->spinBoxRoll  ->value();
+        pitch     = (double)m_ui->spinBoxPitch ->value();
+        heading   = (double)m_ui->spinBoxHead  ->value();
+        slipSkid  = (double)m_ui->spinBoxSlip  ->value();
+        turnRate  = (double)m_ui->spinBoxTurn  ->value();
+        devH      = (double)m_ui->spinBoxDevH  ->value();
+        devV      = (double)m_ui->spinBoxDevV  ->value();
+        airspeed  = (double)m_ui->spinBoxSpeed ->value();
+        pressure  = (double)m_ui->spinBoxPress ->value();
+        altitude  = (double)m_ui->spinBoxAlt   ->value();
+        climbRate = (double)m_ui->spinBoxClimb ->value();
+        machNo    = (double)m_ui->spinBoxMach  ->value();
+        adf       = (double)m_ui->spinBoxADF   ->value();
+        dme       = (double)m_ui->spinBoxDME   ->value();
     }
 
     m_ui->widgetPFD->setFlightPathMarker ( alpha, beta );

--- a/src/example/MainWindow.cpp
+++ b/src/example/MainWindow.cpp
@@ -100,43 +100,43 @@ void MainWindow::timerEvent( QTimerEvent *event )
 
     double timeStep = m_time.restart();
 
-    m_realTime = m_realTime + timeStep / 1000.0f;
+    m_realTime = m_realTime + timeStep / 1000.0;
 
-    double alpha     =  0.0f;
-    double beta      =  0.0f;
-    double roll      =  0.0f;
-    double pitch     =  0.0f;
-    double heading   =  0.0f;
-    double slipSkid  =  0.0f;
-    double turnRate  =  0.0f;
-    double devH      =  0.0f;
-    double devV      =  0.0f;
-    double airspeed  =  0.0f;
-    double altitude  =  0.0f;
-    double pressure  = 28.0f;
-    double climbRate =  0.0f;
-    double machNo    =  0.0f;
-    double adf       =  0.0f;
-    double dme       =  0.0f;
+    double alpha     =  0.0;
+    double beta      =  0.0;
+    double roll      =  0.0;
+    double pitch     =  0.0;
+    double heading   =  0.0;
+    double slipSkid  =  0.0;
+    double turnRate  =  0.0;
+    double devH      =  0.0;
+    double devV      =  0.0;
+    double airspeed  =  0.0;
+    double altitude  =  0.0;
+    double pressure  = 28.0;
+    double climbRate =  0.0;
+    double machNo    =  0.0;
+    double adf       =  0.0;
+    double dme       =  0.0;
 
     if ( m_ui->pushButtonAuto->isChecked() )
     {
-        alpha     =   20.0f * sin( m_realTime /  10.0f );
-        beta      =   15.0f * sin( m_realTime /  10.0f );
-        roll      =  180.0f * sin( m_realTime /  10.0f );
-        pitch     =   90.0f * sin( m_realTime /  20.0f );
-        heading   =  360.0f * sin( m_realTime /  40.0f );
-        slipSkid  =    1.0f * sin( m_realTime /  10.0f );
-        turnRate  =    7.0f * sin( m_realTime /  10.0f );
-        devH      =    1.0f * sin( m_realTime /  20.0f );
-        devV      =    1.0f * sin( m_realTime /  20.0f );
-        airspeed  =  125.0f * sin( m_realTime /  40.0f ) +  125.0f;
-        altitude  = 9000.0f * sin( m_realTime /  40.0f ) + 9000.0f;
-        pressure  =    2.0f * sin( m_realTime /  20.0f ) +   30.0f;
-        climbRate =  650.0f * sin( m_realTime /  20.0f );
-        machNo    = airspeed / 650.0f;
-        adf       = -360.0f * sin( m_realTime /  50.0f );
-        dme       =   99.0f * sin( m_realTime / 100.0f );
+        alpha     =   20.0 * sin( m_realTime /  10.0 );
+        beta      =   15.0 * sin( m_realTime /  10.0 );
+        roll      =  180.0 * sin( m_realTime /  10.0 );
+        pitch     =   90.0 * sin( m_realTime /  20.0 );
+        heading   =  360.0 * sin( m_realTime /  40.0 );
+        slipSkid  =    1.0 * sin( m_realTime /  10.0 );
+        turnRate  =    7.0 * sin( m_realTime /  10.0 );
+        devH      =    1.0 * sin( m_realTime /  20.0 );
+        devV      =    1.0 * sin( m_realTime /  20.0 );
+        airspeed  =  125.0 * sin( m_realTime /  40.0 ) +  125.0;
+        altitude  = 9000.0 * sin( m_realTime /  40.0 ) + 9000.0;
+        pressure  =    2.0 * sin( m_realTime /  20.0 ) +   30.0;
+        climbRate =  650.0 * sin( m_realTime /  20.0 );
+        machNo    = airspeed / 650.0;
+        adf       = -360.0 * sin( m_realTime /  50.0 );
+        dme       =   99.0 * sin( m_realTime / 100.0 );
 
         m_ui->spinBoxAlpha->setValue( alpha     );
         m_ui->spinBoxBeta->setValue( beta      );
@@ -179,7 +179,7 @@ void MainWindow::timerEvent( QTimerEvent *event )
     m_ui->widgetPFD->setRoll          ( roll     );
     m_ui->widgetPFD->setPitch         ( pitch     );
     m_ui->widgetPFD->setSlipSkid      ( slipSkid  );
-    m_ui->widgetPFD->setTurnRate      ( turnRate / 6.0f );
+    m_ui->widgetPFD->setTurnRate      ( turnRate / 6.0 );
     m_ui->widgetPFD->setDevH          ( devH      );
     m_ui->widgetPFD->setDevV          ( devV      );
     m_ui->widgetPFD->setHeading       ( heading   );
@@ -187,13 +187,13 @@ void MainWindow::timerEvent( QTimerEvent *event )
     m_ui->widgetPFD->setMachNo        ( machNo    );
     m_ui->widgetPFD->setAltitude      ( altitude  );
     m_ui->widgetPFD->setPressure      ( pressure  );
-    m_ui->widgetPFD->setClimbRate     ( climbRate / 100.0f );
+    m_ui->widgetPFD->setClimbRate     ( climbRate / 100.0 );
     m_ui->widgetPFD->setIdentifier    ( "ILAX" , true );
     m_ui->widgetPFD->setDistance      ( dme    , true );
 
     m_ui->widgetNAV->setHeading    ( heading   );
-    m_ui->widgetNAV->setHeadingBug ( 0.0f );
-    m_ui->widgetNAV->setCourse     ( 0.0f );
+    m_ui->widgetNAV->setHeadingBug ( 0.0 );
+    m_ui->widgetNAV->setCourse     ( 0.0 );
     m_ui->widgetNAV->setBearing    ( adf  , true );
     m_ui->widgetNAV->setDeviation  ( devH , true );
     m_ui->widgetNAV->setDistance   ( dme  , true );
@@ -204,7 +204,7 @@ void MainWindow::timerEvent( QTimerEvent *event )
     m_ui->widgetSix->setPressure  ( pressure  );
     m_ui->widgetSix->setAirspeed  ( airspeed  );
     m_ui->widgetSix->setHeading   ( heading   );
-    m_ui->widgetSix->setSlipSkid  ( slipSkid * 15.0f );
+    m_ui->widgetSix->setSlipSkid  ( slipSkid * 15.0 );
     m_ui->widgetSix->setTurnRate  ( turnRate  );
     m_ui->widgetSix->setClimbRate ( climbRate );
 

--- a/src/example/MainWindow.h
+++ b/src/example/MainWindow.h
@@ -82,7 +82,7 @@ private:
     int m_timerId;
     int m_steps;
 
-    float m_realTime;
+    double m_realTime;
 
     QTime m_time;
 };

--- a/src/example/WidgetADI.h
+++ b/src/example/WidgetADI.h
@@ -80,12 +80,12 @@ public:
         m_adi->update();
     }
 
-    inline void setRoll( float roll )
+    inline void setRoll( double roll )
     {
         m_adi->setRoll( roll );
     }
 
-    inline void setPitch( float pitch )
+    inline void setPitch( double pitch )
     {
         m_adi->setPitch( pitch );
     }

--- a/src/example/WidgetALT.h
+++ b/src/example/WidgetALT.h
@@ -80,12 +80,12 @@ public:
         m_alt->update();
     }
 
-    inline void setAltitude( float altitude )
+    inline void setAltitude( double altitude )
     {
         m_alt->setAltitude( altitude );
     }
 
-    inline void setPressure( float pressure )
+    inline void setPressure( double pressure )
     {
         m_alt->setPressure( pressure );
     }

--- a/src/example/WidgetASI.h
+++ b/src/example/WidgetASI.h
@@ -80,7 +80,7 @@ public:
         m_asi->update();
     }
 
-    inline void setAirspeed( float airspeed )
+    inline void setAirspeed( double airspeed )
     {
         m_asi->setAirspeed( airspeed );
     }

--- a/src/example/WidgetHSI.h
+++ b/src/example/WidgetHSI.h
@@ -80,7 +80,7 @@ public:
         m_hsi->update();
     }
 
-    inline void setHeading( float heading )
+    inline void setHeading( double heading )
     {
         m_hsi->setHeading( heading );
     }

--- a/src/example/WidgetNAV.h
+++ b/src/example/WidgetNAV.h
@@ -80,32 +80,32 @@ public:
         m_nav->update();
     }
 
-    inline void setHeading( float heading )
+    inline void setHeading( double heading )
     {
         m_nav->setHeading( heading );
     }
 
-    inline void setHeadingBug( float headingBug )
+    inline void setHeadingBug( double headingBug )
     {
         m_nav->setHeadingBug( headingBug );
     }
 
-    inline void setCourse( float course )
+    inline void setCourse( double course )
     {
         m_nav->setCourse( course );
     }
 
-    inline void setBearing( float bearing, bool visible = false )
+    inline void setBearing( double bearing, bool visible = false )
     {
         m_nav->setBearing( bearing, visible );
     }
 
-    inline void setDeviation( float deviation, bool visible = false )
+    inline void setDeviation( double deviation, bool visible = false )
     {
         m_nav->setDeviation( deviation, visible );
     }
 
-    inline void setDistance( float distance, bool visible = false )
+    inline void setDistance( double distance, bool visible = false )
     {
         m_nav->setDistance( distance, visible );
     }

--- a/src/example/WidgetPFD.h
+++ b/src/example/WidgetPFD.h
@@ -81,69 +81,69 @@ public:
         m_pfd->update();
     }
 
-    inline void setRoll( float roll )
+    inline void setRoll( double roll )
     {
         m_pfd->setRoll( roll );
     }
 
-    inline void setPitch( float pitch )
+    inline void setPitch( double pitch )
     {
         m_pfd->setPitch( pitch );
     }
 
-    inline void setFlightPathMarker( float aoa, float sideslip )
+    inline void setFlightPathMarker( double aoa, double sideslip )
     {
         m_pfd->setFlightPathMarker( aoa, sideslip );
     }
 
-    inline void setSlipSkid( float slipSkid )
+    inline void setSlipSkid( double slipSkid )
     {
         m_pfd->setSlipSkid( slipSkid );
     }
 
-    inline void setDevH( float devH )
+    inline void setDevH( double devH )
     {
         m_pfd->setBarH( devH );
         m_pfd->setDotH( devH );
     }
 
-    inline void setDevV( float devV )
+    inline void setDevV( double devV )
     {
         m_pfd->setBarV( devV );
         m_pfd->setDotV( devV );
     }
 
-    inline void setAltitude( float altitude )
+    inline void setAltitude( double altitude )
     {
         m_pfd->setAltitude( altitude );
     }
 
-    inline void setPressure( float pressure )
+    inline void setPressure( double pressure )
     {
         m_pfd->setPressure( pressure, qfi_PFD::IN );
     }
 
-    inline void setAirspeed( float airspeed )
+    inline void setAirspeed( double airspeed )
     {
         m_pfd->setAirspeed( airspeed );
     }
 
-    inline void setMachNo( float machNo )
+    inline void setMachNo( double machNo )
     {
         m_pfd->setMachNo( machNo );
     }
 
-    inline void setHeading( float heading )
+    inline void setHeading( double heading )
     {
         m_pfd->setHeading( heading );
     }
 
-    inline void setTurnRate( float turnRate )
+    inline void setTurnRate( double turnRate )
     {
         m_pfd->setTurnRate( turnRate );
     }
 
-    inline void setClimbRate( float climbRate )
+    inline void setClimbRate( double climbRate )
     {
         m_pfd->setClimbRate( climbRate );
     }
@@ -153,7 +153,7 @@ public:
         m_pfd->setIdent( ident, isVisible );
     }
 
-    inline void setDistance( float dist, bool isVisible )
+    inline void setDistance( double dist, bool isVisible )
     {
         m_pfd->setDistance( dist, isVisible );
     }

--- a/src/example/WidgetSix.h
+++ b/src/example/WidgetSix.h
@@ -80,47 +80,47 @@ public:
 
     void update();
 
-    inline void setRoll( float roll )
+    inline void setRoll( double roll )
     {
         m_widgetADI->setRoll( roll );
     }
 
-    inline void setPitch( float pitch )
+    inline void setPitch( double pitch )
     {
         m_widgetADI->setPitch( pitch );
     }
 
-    inline void setAltitude( float altitude )
+    inline void setAltitude( double altitude )
     {
         m_widgetALT->setAltitude( altitude );
     }
 
-    inline void setPressure( float pressure )
+    inline void setPressure( double pressure )
     {
         m_widgetALT->setPressure( pressure );
     }
 
-    inline void setAirspeed( float airspeed )
+    inline void setAirspeed( double airspeed )
     {
         m_widgetASI->setAirspeed( airspeed );
     }
 
-    inline void setHeading( float heading )
+    inline void setHeading( double heading )
     {
         m_widgetHSI->setHeading( heading );
     }
 
-    inline void setTurnRate( float turnRate )
+    inline void setTurnRate( double turnRate )
     {
         m_widgetTC->setTurnRate( turnRate );
     }
 
-    inline void setSlipSkid( float slipSkid )
+    inline void setSlipSkid( double slipSkid )
     {
         m_widgetTC->setSlipSkid( slipSkid );
     }
 
-    inline void setClimbRate( float climbRate )
+    inline void setClimbRate( double climbRate )
     {
         m_widgetVSI->setClimbRate( climbRate );
     }

--- a/src/example/WidgetTC.h
+++ b/src/example/WidgetTC.h
@@ -80,12 +80,12 @@ public:
         m_tc->update();
     }
 
-    inline void setTurnRate( float turnRate )
+    inline void setTurnRate( double turnRate )
     {
         m_tc->setTurnRate( turnRate );
     }
 
-    inline void setSlipSkid( float slipSkid )
+    inline void setSlipSkid( double slipSkid )
     {
         m_tc->setSlipSkid( slipSkid );
     }

--- a/src/example/WidgetVSI.h
+++ b/src/example/WidgetVSI.h
@@ -80,7 +80,7 @@ public:
         m_vsi->update();
     }
 
-    inline void setClimbRate( float climbRate )
+    inline void setClimbRate( double climbRate )
     {
         m_vsi->setClimbRate( climbRate );
     }

--- a/src/qfi_ADI.cpp
+++ b/src/qfi_ADI.cpp
@@ -171,8 +171,8 @@ void qfi_ADI::resizeEvent( QResizeEvent *event )
 
 void qfi_ADI::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     reset();
 
@@ -230,8 +230,8 @@ void qfi_ADI::reset()
 
 void qfi_ADI::updateView()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     m_itemBack->setRotation( - m_roll );
     m_itemFace->setRotation( - m_roll );

--- a/src/qfi_ADI.cpp
+++ b/src/qfi_ADI.cpp
@@ -67,23 +67,23 @@ qfi_ADI::qfi_ADI( QWidget *parent ) :
     m_itemRing ( 0 ),
     m_itemCase ( 0 ),
 
-    m_roll  ( 0.0f ),
-    m_pitch ( 0.0f ),
+    m_roll  ( 0.0 ),
+    m_pitch ( 0.0 ),
 
-    m_faceDeltaX_new ( 0.0f ),
-    m_faceDeltaX_old ( 0.0f ),
-    m_faceDeltaY_new ( 0.0f ),
-    m_faceDeltaY_old ( 0.0f ),
+    m_faceDeltaX_new ( 0.0 ),
+    m_faceDeltaX_old ( 0.0 ),
+    m_faceDeltaY_new ( 0.0 ),
+    m_faceDeltaY_old ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 240 ),
     m_originalWidth  ( 240 ),
 
-    m_originalPixPerDeg ( 1.7f ),
+    m_originalPixPerDeg ( 1.7 ),
 
-    m_originalAdiCtr ( 120.0f , 120.0f ),
+    m_originalAdiCtr ( 120.0 , 120.0 ),
 
     m_backZ ( -30 ),
     m_faceZ ( -20 ),
@@ -142,8 +142,8 @@ void qfi_ADI::setRoll( double roll )
 {
     m_roll = roll;
 
-    if ( m_roll < -180.0f ) m_roll = -180.0f;
-    if ( m_roll >  180.0f ) m_roll =  180.0f;
+    if ( m_roll < -180.0 ) m_roll = -180.0;
+    if ( m_roll >  180.0 ) m_roll =  180.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -152,8 +152,8 @@ void qfi_ADI::setPitch( double pitch )
 {
     m_pitch = pitch;
 
-    if ( m_pitch < -25.0f ) m_pitch = -25.0f;
-    if ( m_pitch >  25.0f ) m_pitch =  25.0f;
+    if ( m_pitch < -25.0 ) m_pitch = -25.0;
+    if ( m_pitch >  25.0 ) m_pitch =  25.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -203,7 +203,7 @@ void qfi_ADI::init()
     m_itemCase->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemCase );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -217,13 +217,13 @@ void qfi_ADI::reset()
     m_itemRing = 0;
     m_itemCase = 0;
 
-    m_roll  = 0.0f;
-    m_pitch = 0.0f;
+    m_roll  = 0.0;
+    m_pitch = 0.0;
 
-    m_faceDeltaX_new = 0.0f;
-    m_faceDeltaX_old = 0.0f;
-    m_faceDeltaY_new = 0.0f;
-    m_faceDeltaY_old = 0.0f;
+    m_faceDeltaX_new = 0.0;
+    m_faceDeltaX_old = 0.0;
+    m_faceDeltaY_new = 0.0;
+    m_faceDeltaY_old = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/qfi_ADI.cpp
+++ b/src/qfi_ADI.cpp
@@ -51,10 +51,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 
 #include "qfi_ADI.h"
@@ -142,7 +138,7 @@ void qfi_ADI::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_ADI::setRoll( float roll )
+void qfi_ADI::setRoll( double roll )
 {
     m_roll = roll;
 
@@ -152,7 +148,7 @@ void qfi_ADI::setRoll( float roll )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_ADI::setPitch( float pitch )
+void qfi_ADI::setPitch( double pitch )
 {
     m_pitch = pitch;
 
@@ -175,8 +171,8 @@ void qfi_ADI::resizeEvent( QResizeEvent *event )
 
 void qfi_ADI::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     reset();
 
@@ -234,16 +230,16 @@ void qfi_ADI::reset()
 
 void qfi_ADI::updateView()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     m_itemBack->setRotation( - m_roll );
     m_itemFace->setRotation( - m_roll );
     m_itemRing->setRotation( - m_roll );
 
-    float roll_rad = M_PI * m_roll / 180.0;
+    double roll_rad = M_PI * m_roll / 180.0;
 
-    float delta  = m_originalPixPerDeg * m_pitch;
+    double delta  = m_originalPixPerDeg * m_pitch;
 
     m_faceDeltaX_new = m_scaleX * delta * sin( roll_rad );
     m_faceDeltaY_new = m_scaleY * delta * cos( roll_rad );

--- a/src/qfi_ADI.h
+++ b/src/qfi_ADI.h
@@ -75,10 +75,10 @@ public:
     void update();
 
     /** @param roll angle [deg] */
-    void setRoll( float roll );
+    void setRoll( double roll );
 
     /** @param pitch angle [deg] */
-    void setPitch( float pitch );
+    void setPitch( double pitch );
 
 protected:
 
@@ -93,21 +93,21 @@ private:
     QGraphicsSvgItem *m_itemRing;
     QGraphicsSvgItem *m_itemCase;
 
-    float m_roll;
-    float m_pitch;
+    double m_roll;
+    double m_pitch;
 
-    float m_faceDeltaX_new;
-    float m_faceDeltaX_old;
-    float m_faceDeltaY_new;
-    float m_faceDeltaY_old;
+    double m_faceDeltaX_new;
+    double m_faceDeltaX_old;
+    double m_faceDeltaY_new;
+    double m_faceDeltaY_old;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;
 
-    const float m_originalPixPerDeg;
+    const double m_originalPixPerDeg;
 
     QPointF m_originalAdiCtr;
 

--- a/src/qfi_ALT.cpp
+++ b/src/qfi_ALT.cpp
@@ -162,8 +162,8 @@ void qfi_ALT::resizeEvent( QResizeEvent *event )
 
 void qfi_ALT::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     reset();
 

--- a/src/qfi_ALT.cpp
+++ b/src/qfi_ALT.cpp
@@ -69,16 +69,16 @@ qfi_ALT::qfi_ALT( QWidget *parent ) :
     m_itemHand_2 ( 0 ),
     m_itemCase   ( 0 ),
 
-    m_altitude (  0.0f ),
-    m_pressure ( 28.0f ),
+    m_altitude (  0.0 ),
+    m_pressure ( 28.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 240 ),
     m_originalWidth  ( 240 ),
 
-    m_originalAltCtr ( 120.0f , 120.0f ),
+    m_originalAltCtr ( 120.0 , 120.0 ),
 
     m_face1Z ( -50 ),
     m_face2Z ( -40 ),
@@ -143,8 +143,8 @@ void qfi_ALT::setPressure( double pressure )
 {
     m_pressure = pressure;
 
-    if ( m_pressure < 28.0f ) m_pressure = 28.0f;
-    if ( m_pressure > 31.5f ) m_pressure = 31.5f;
+    if ( m_pressure < 28.0 ) m_pressure = 28.0;
+    if ( m_pressure > 31.5 ) m_pressure = 31.5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -207,7 +207,7 @@ void qfi_ALT::init()
     m_itemCase->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemCase );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -223,8 +223,8 @@ void qfi_ALT::reset()
     m_itemHand_2 = 0;
     m_itemCase   = 0;
 
-    m_altitude =  0.0f;
-    m_pressure = 28.0f;
+    m_altitude =  0.0;
+    m_pressure = 28.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -233,10 +233,10 @@ void qfi_ALT::updateView()
 {
     int altitude = ceil( m_altitude + 0.5 );
 
-    double angleH1 = m_altitude * 0.036f;
-    double angleH2 = ( altitude % 1000 ) * 0.36f;
-    double angleF1 = ( m_pressure - 28.0f ) * 100.0f;
-    double angleF3 = m_altitude * 0.0036f;
+    double angleH1 = m_altitude * 0.036;
+    double angleH2 = ( altitude % 1000 ) * 0.36;
+    double angleF1 = ( m_pressure - 28.0 ) * 100.0;
+    double angleF3 = m_altitude * 0.0036;
 
     m_itemHand_1->setRotation(   angleH1 );
     m_itemHand_2->setRotation(   angleH2 );

--- a/src/qfi_ALT.cpp
+++ b/src/qfi_ALT.cpp
@@ -51,10 +51,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 
 #include "qfi_ALT.h"
@@ -136,14 +132,14 @@ void qfi_ALT::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_ALT::setAltitude( float altitude )
+void qfi_ALT::setAltitude( double altitude )
 {
     m_altitude = altitude;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_ALT::setPressure( float pressure )
+void qfi_ALT::setPressure( double pressure )
 {
     m_pressure = pressure;
 
@@ -166,8 +162,8 @@ void qfi_ALT::resizeEvent( QResizeEvent *event )
 
 void qfi_ALT::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     reset();
 
@@ -237,10 +233,10 @@ void qfi_ALT::updateView()
 {
     int altitude = ceil( m_altitude + 0.5 );
 
-    float angleH1 = m_altitude * 0.036f;
-    float angleH2 = ( altitude % 1000 ) * 0.36f;
-    float angleF1 = ( m_pressure - 28.0f ) * 100.0f;
-    float angleF3 = m_altitude * 0.0036f;
+    double angleH1 = m_altitude * 0.036f;
+    double angleH2 = ( altitude % 1000 ) * 0.36f;
+    double angleF1 = ( m_pressure - 28.0f ) * 100.0f;
+    double angleF3 = m_altitude * 0.0036f;
 
     m_itemHand_1->setRotation(   angleH1 );
     m_itemHand_2->setRotation(   angleH2 );

--- a/src/qfi_ALT.h
+++ b/src/qfi_ALT.h
@@ -75,10 +75,10 @@ public:
     void update();
 
     /** @param altitude [ft] */
-    void setAltitude( float altitude );
+    void setAltitude( double altitude );
 
     /** @param pressure [inHg] */
-    void setPressure( float aressure );
+    void setPressure( double aressure );
 
 protected:
 
@@ -95,11 +95,11 @@ private:
     QGraphicsSvgItem *m_itemHand_2;
     QGraphicsSvgItem *m_itemCase;
 
-    float m_altitude;
-    float m_pressure;
+    double m_altitude;
+    double m_pressure;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;

--- a/src/qfi_ASI.cpp
+++ b/src/qfi_ASI.cpp
@@ -148,8 +148,8 @@ void qfi_ASI::resizeEvent( QResizeEvent *event )
 
 void qfi_ASI::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     reset();
 

--- a/src/qfi_ASI.cpp
+++ b/src/qfi_ASI.cpp
@@ -66,15 +66,15 @@ qfi_ASI::qfi_ASI( QWidget *parent ) :
     m_itemHand ( 0 ),
     m_itemCase ( 0 ),
 
-    m_airspeed ( 0.0f ),
+    m_airspeed ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 240 ),
     m_originalWidth  ( 240 ),
 
-    m_originalAsiCtr ( 120.0f , 120.0f ),
+    m_originalAsiCtr ( 120.0 , 120.0 ),
 
     m_faceZ ( -20 ),
     m_handZ ( -10 ),
@@ -129,8 +129,8 @@ void qfi_ASI::setAirspeed( double airspeed )
 {
     m_airspeed = airspeed;
 
-    if ( m_airspeed <   0.0f ) m_airspeed =   0.0f;
-    if ( m_airspeed > 235.0f ) m_airspeed = 235.0f;
+    if ( m_airspeed <   0.0 ) m_airspeed =   0.0;
+    if ( m_airspeed > 235.0 ) m_airspeed = 235.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -172,7 +172,7 @@ void qfi_ASI::init()
     m_itemCase->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemCase );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -185,34 +185,34 @@ void qfi_ASI::reset()
     m_itemHand = 0;
     m_itemCase = 0;
 
-    m_airspeed = 0.0f;
+    m_airspeed = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void qfi_ASI::updateView()
 {
-    double angle = 0.0f;
+    double angle = 0.0;
 
-    if ( m_airspeed < 40.0f )
+    if ( m_airspeed < 40.0 )
     {
-        angle = 0.9f * m_airspeed;
+        angle = 0.9 * m_airspeed;
     }
-    else if ( m_airspeed < 70.0f )
+    else if ( m_airspeed < 70.0 )
     {
-        angle = 36.0f + 1.8f * ( m_airspeed - 40.0f );
+        angle = 36.0 + 1.8 * ( m_airspeed - 40.0 );
     }
-    else if ( m_airspeed < 130.0f )
+    else if ( m_airspeed < 130.0 )
     {
-        angle = 90.0f + 2.0f * ( m_airspeed - 70.0f );
+        angle = 90.0 + 2.0 * ( m_airspeed - 70.0 );
     }
-    else if ( m_airspeed < 160.0f )
+    else if ( m_airspeed < 160.0 )
     {
-        angle = 210.0f + 1.8f * ( m_airspeed - 130.0f );
+        angle = 210.0 + 1.8 * ( m_airspeed - 130.0 );
     }
     else
     {
-        angle = 264.0f + 1.2f * ( m_airspeed - 160.0f );
+        angle = 264.0 + 1.2 * ( m_airspeed - 160.0 );
     }
 
     m_itemHand->setRotation( angle );

--- a/src/qfi_ASI.cpp
+++ b/src/qfi_ASI.cpp
@@ -51,10 +51,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 
 #include "qfi_ASI.h"
@@ -129,7 +125,7 @@ void qfi_ASI::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_ASI::setAirspeed( float airspeed )
+void qfi_ASI::setAirspeed( double airspeed )
 {
     m_airspeed = airspeed;
 
@@ -152,8 +148,8 @@ void qfi_ASI::resizeEvent( QResizeEvent *event )
 
 void qfi_ASI::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     reset();
 
@@ -196,7 +192,7 @@ void qfi_ASI::reset()
 
 void qfi_ASI::updateView()
 {
-    float angle = 0.0f;
+    double angle = 0.0f;
 
     if ( m_airspeed < 40.0f )
     {

--- a/src/qfi_ASI.h
+++ b/src/qfi_ASI.h
@@ -75,7 +75,7 @@ public:
     void update();
 
     /** @param airspeed [kts] */
-    void setAirspeed( float airspeed );
+    void setAirspeed( double airspeed );
 
 protected:
 
@@ -89,10 +89,10 @@ private:
     QGraphicsSvgItem *m_itemHand;
     QGraphicsSvgItem *m_itemCase;
 
-    float m_airspeed;
+    double m_airspeed;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;

--- a/src/qfi_HSI.cpp
+++ b/src/qfi_HSI.cpp
@@ -65,15 +65,15 @@ qfi_HSI::qfi_HSI( QWidget *parent ) :
     m_itemFace ( 0 ),
     m_itemCase ( 0 ),
 
-    m_heading ( 0.0f ),
+    m_heading ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 240 ),
     m_originalWidth  ( 240 ),
 
-    m_originalHsiCtr ( 120.0f , 120.0f ),
+    m_originalHsiCtr ( 120.0 , 120.0 ),
 
     m_faceZ ( -20 ),
     m_caseZ (  10 )
@@ -161,7 +161,7 @@ void qfi_HSI::init()
     m_itemCase->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemCase );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -173,7 +173,7 @@ void qfi_HSI::reset()
     m_itemFace = 0;
     m_itemCase = 0;
 
-    m_heading = 0.0f;
+    m_heading = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/qfi_HSI.cpp
+++ b/src/qfi_HSI.cpp
@@ -143,8 +143,8 @@ void qfi_HSI::resizeEvent( QResizeEvent *event )
 
 void qfi_HSI::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     reset();
 

--- a/src/qfi_HSI.cpp
+++ b/src/qfi_HSI.cpp
@@ -51,10 +51,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 
 #include "qfi_HSI.h"
@@ -127,7 +123,7 @@ void qfi_HSI::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_HSI::setHeading( float heading )
+void qfi_HSI::setHeading( double heading )
 {
     m_heading = heading;
 }
@@ -147,8 +143,8 @@ void qfi_HSI::resizeEvent( QResizeEvent *event )
 
 void qfi_HSI::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     reset();
 

--- a/src/qfi_HSI.h
+++ b/src/qfi_HSI.h
@@ -75,7 +75,7 @@ public:
     void update();
 
     /** @param heading [deg] */
-    void setHeading( float heading );
+    void setHeading( double heading );
 
 protected:
 
@@ -88,10 +88,10 @@ private:
     QGraphicsSvgItem *m_itemFace;
     QGraphicsSvgItem *m_itemCase;
 
-    float m_heading;
+    double m_heading;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;

--- a/src/qfi_NAV.cpp
+++ b/src/qfi_NAV.cpp
@@ -53,10 +53,6 @@
 
 #include <iostream>
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 #include <stdio.h>
 
@@ -212,7 +208,7 @@ void qfi_NAV::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_NAV::setHeading( float heading )
+void qfi_NAV::setHeading( double heading )
 {
     m_heading = heading;
 
@@ -222,7 +218,7 @@ void qfi_NAV::setHeading( float heading )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_NAV::setHeadingBug( float headingBug )
+void qfi_NAV::setHeadingBug( double headingBug )
 {
     m_headingBug = headingBug;
 
@@ -232,7 +228,7 @@ void qfi_NAV::setHeadingBug( float headingBug )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_NAV::setCourse( float course )
+void qfi_NAV::setCourse( double course )
 {
     m_course = course;
 
@@ -242,7 +238,7 @@ void qfi_NAV::setCourse( float course )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_NAV::setBearing( float bearing, bool visible )
+void qfi_NAV::setBearing( double bearing, bool visible )
 {
     m_bearing        = bearing;
     m_bearingVisible = visible;
@@ -253,7 +249,7 @@ void qfi_NAV::setBearing( float bearing, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_NAV::setDeviation( float deviation, bool visible )
+void qfi_NAV::setDeviation( double deviation, bool visible )
 {
     m_deviation        = deviation;
     m_deviationVisible = visible;
@@ -264,7 +260,7 @@ void qfi_NAV::setDeviation( float deviation, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_NAV::setDistance( float distance, bool visible )
+void qfi_NAV::setDistance( double distance, bool visible )
 {
     m_distance        = fabs( distance );
     m_distanceVisible = visible;
@@ -285,8 +281,8 @@ void qfi_NAV::resizeEvent( QResizeEvent *event )
 
 void qfi_NAV::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     m_itemBack = new QGraphicsSvgItem( ":/qfi/images/nav/nav_back.svg" );
     m_itemBack->setCacheMode( QGraphicsItem::NoCache );
@@ -419,8 +415,8 @@ void qfi_NAV::reset()
 
 void qfi_NAV::updateView()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     m_itemCrsArrow->setRotation( -m_heading + m_course );
     m_itemHdgBug->setRotation( -m_heading + m_headingBug );
@@ -441,21 +437,21 @@ void qfi_NAV::updateView()
         m_itemDevBar->setVisible( true );
         m_itemDevScale->setVisible( true );
 
-        float angle_deg = -m_heading + m_course;
+        double angle_deg = -m_heading + m_course;
 #       ifndef M_PI
-        float angle_rad = 3.14159265358979323846 * angle_deg / 180.0f;
+        double angle_rad = 3.14159265358979323846 * angle_deg / 180.0f;
 #       else
-        float angle_rad = M_PI * angle_deg / 180.0f;
+        double angle_rad = M_PI * angle_deg / 180.0f;
 #       endif
 
 
-        float sinAngle = sin( angle_rad );
-        float cosAngle = cos( angle_rad );
+        double sinAngle = sin( angle_rad );
+        double cosAngle = cos( angle_rad );
 
         m_itemDevBar->setRotation( angle_deg );
         m_itemDevScale->setRotation( angle_deg );
 
-        float delta  = m_originalPixPerDev * m_deviation;
+        double delta  = m_originalPixPerDev * m_deviation;
 
         m_devBarDeltaX_new = m_scaleX * delta * cosAngle;
         m_devBarDeltaY_new = m_scaleY * delta * sinAngle;

--- a/src/qfi_NAV.cpp
+++ b/src/qfi_NAV.cpp
@@ -84,32 +84,32 @@ qfi_NAV::qfi_NAV( QWidget *parent ) :
     m_hdgTextColor ( 255,   0, 255 ),
     m_dmeTextColor ( 255, 255, 255 ),
 
-    m_heading    ( 0.0f ),
-    m_headingBug ( 0.0f ),
-    m_course     ( 0.0f ),
-    m_bearing    ( 0.0f ),
-    m_deviation  ( 0.0f ),
-    m_distance   ( 0.0f ),
+    m_heading    ( 0.0 ),
+    m_headingBug ( 0.0 ),
+    m_course     ( 0.0 ),
+    m_bearing    ( 0.0 ),
+    m_deviation  ( 0.0 ),
+    m_distance   ( 0.0 ),
 
     m_bearingVisible   ( true ),
     m_deviationVisible ( true ),
     m_distanceVisible  ( true ),
 
-    m_devBarDeltaX_new ( 0.0f ),
-    m_devBarDeltaX_old ( 0.0f ),
-    m_devBarDeltaY_new ( 0.0f ),
-    m_devBarDeltaY_old ( 0.0f ),
+    m_devBarDeltaX_new ( 0.0 ),
+    m_devBarDeltaX_old ( 0.0 ),
+    m_devBarDeltaY_new ( 0.0 ),
+    m_devBarDeltaY_old ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalPixPerDev ( 52.5f ),
+    m_originalPixPerDev ( 52.5 ),
 
-    m_originalNavCtr ( 150.0f, 150.0f ),
+    m_originalNavCtr ( 150.0, 150.0 ),
 
-    m_originalCrsTextCtr (  50.0f,  25.0f ),
-    m_originalHdgTextCtr ( 250.0f,  25.0f ),
-    m_originalDmeTextCtr ( 250.0f, 275.0f ),
+    m_originalCrsTextCtr (  50.0,  25.0 ),
+    m_originalHdgTextCtr ( 250.0,  25.0 ),
+    m_originalDmeTextCtr ( 250.0, 275.0 ),
 
     m_originalHeight ( 300 ),
     m_originalWidth  ( 300 ),
@@ -130,32 +130,32 @@ qfi_NAV::qfi_NAV( QWidget *parent ) :
 {
 #   ifdef WIN32
     m_crsTextFont.setFamily( "Courier" );
-    m_crsTextFont.setPointSizeF( 12.0f );
+    m_crsTextFont.setPointSizeF( 12.0 );
     m_crsTextFont.setStretch( QFont::Condensed );
     m_crsTextFont.setWeight( QFont::Bold );
 
     m_hdgTextFont.setFamily( "Courier" );
-    m_hdgTextFont.setPointSizeF( 12.0f );
+    m_hdgTextFont.setPointSizeF( 12.0 );
     m_hdgTextFont.setStretch( QFont::Condensed );
     m_hdgTextFont.setWeight( QFont::Bold );
 
     m_dmeTextFont.setFamily( "Courier" );
-    m_dmeTextFont.setPointSizeF( 10.0f );
+    m_dmeTextFont.setPointSizeF( 10.0 );
     m_dmeTextFont.setStretch( QFont::Condensed );
     m_dmeTextFont.setWeight( QFont::Bold );
 #   else
     m_crsTextFont.setFamily( "courier" );
-    m_crsTextFont.setPointSizeF( 12.0f );
+    m_crsTextFont.setPointSizeF( 12.0 );
     m_crsTextFont.setStretch( QFont::Condensed );
     m_crsTextFont.setWeight( QFont::Bold );
 
     m_hdgTextFont.setFamily( "courier" );
-    m_hdgTextFont.setPointSizeF( 12.0f );
+    m_hdgTextFont.setPointSizeF( 12.0 );
     m_hdgTextFont.setStretch( QFont::Condensed );
     m_hdgTextFont.setWeight( QFont::Bold );
 
     m_dmeTextFont.setFamily( "courier" );
-    m_dmeTextFont.setPointSizeF( 10.0f );
+    m_dmeTextFont.setPointSizeF( 10.0 );
     m_dmeTextFont.setStretch( QFont::Condensed );
     m_dmeTextFont.setWeight( QFont::Bold );
 #   endif
@@ -212,8 +212,8 @@ void qfi_NAV::setHeading( double heading )
 {
     m_heading = heading;
 
-    while ( m_heading <   0.0f ) m_heading += 360.0f;
-    while ( m_heading > 360.0f ) m_heading -= 360.0f;
+    while ( m_heading <   0.0 ) m_heading += 360.0;
+    while ( m_heading > 360.0 ) m_heading -= 360.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -222,8 +222,8 @@ void qfi_NAV::setHeadingBug( double headingBug )
 {
     m_headingBug = headingBug;
 
-    while ( m_headingBug <   0.0f ) m_headingBug += 360.0f;
-    while ( m_headingBug > 360.0f ) m_headingBug -= 360.0f;
+    while ( m_headingBug <   0.0 ) m_headingBug += 360.0;
+    while ( m_headingBug > 360.0 ) m_headingBug -= 360.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -232,8 +232,8 @@ void qfi_NAV::setCourse( double course )
 {
     m_course = course;
 
-    while ( m_course <   0.0f ) m_course += 360.0f;
-    while ( m_course > 360.0f ) m_course -= 360.0f;
+    while ( m_course <   0.0 ) m_course += 360.0;
+    while ( m_course > 360.0 ) m_course -= 360.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -243,8 +243,8 @@ void qfi_NAV::setBearing( double bearing, bool visible )
     m_bearing        = bearing;
     m_bearingVisible = visible;
 
-    while ( m_bearing <   0.0f ) m_bearing += 360.0f;
-    while ( m_bearing > 360.0f ) m_bearing -= 360.0f;
+    while ( m_bearing <   0.0 ) m_bearing += 360.0;
+    while ( m_bearing > 360.0 ) m_bearing -= 360.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -254,8 +254,8 @@ void qfi_NAV::setDeviation( double deviation, bool visible )
     m_deviation        = deviation;
     m_deviationVisible = visible;
 
-    if ( m_deviation < -1.0f ) m_deviation = -1.0f;
-    if ( m_deviation >  1.0f ) m_deviation =  1.0f;
+    if ( m_deviation < -1.0 ) m_deviation = -1.0;
+    if ( m_deviation >  1.0 ) m_deviation =  1.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -352,8 +352,8 @@ void qfi_NAV::init()
     m_itemCrsText->setDefaultTextColor( m_crsTextColor );
     m_itemCrsText->setFont( m_crsTextFont );
     m_itemCrsText->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemCrsText->moveBy( m_scaleX * ( m_originalCrsTextCtr.x() - m_itemCrsText->boundingRect().width()  / 2.0f ),
-                           m_scaleY * ( m_originalCrsTextCtr.y() - m_itemCrsText->boundingRect().height() / 2.0f ) );
+    m_itemCrsText->moveBy( m_scaleX * ( m_originalCrsTextCtr.x() - m_itemCrsText->boundingRect().width()  / 2.0 ),
+                           m_scaleY * ( m_originalCrsTextCtr.y() - m_itemCrsText->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemCrsText );
 
     m_itemHdgText = new QGraphicsTextItem( QString( "HDG 999" ) );
@@ -362,8 +362,8 @@ void qfi_NAV::init()
     m_itemHdgText->setDefaultTextColor( m_hdgTextColor );
     m_itemHdgText->setFont( m_hdgTextFont );
     m_itemHdgText->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemHdgText->moveBy( m_scaleX * ( m_originalHdgTextCtr.x() - m_itemHdgText->boundingRect().width()  / 2.0f ),
-                           m_scaleY * ( m_originalHdgTextCtr.y() - m_itemHdgText->boundingRect().height() / 2.0f ) );
+    m_itemHdgText->moveBy( m_scaleX * ( m_originalHdgTextCtr.x() - m_itemHdgText->boundingRect().width()  / 2.0 ),
+                           m_scaleY * ( m_originalHdgTextCtr.y() - m_itemHdgText->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemHdgText );
 
     m_itemDmeText = new QGraphicsTextItem( QString( "99.9 NM" ) );
@@ -372,8 +372,8 @@ void qfi_NAV::init()
     m_itemDmeText->setDefaultTextColor( m_dmeTextColor );
     m_itemDmeText->setFont( m_dmeTextFont );
     m_itemDmeText->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemDmeText->moveBy( m_scaleX * ( m_originalDmeTextCtr.x() - m_itemDmeText->boundingRect().width()  / 2.0f ),
-                           m_scaleY * ( m_originalDmeTextCtr.y() - m_itemDmeText->boundingRect().height() / 2.0f ) );
+    m_itemDmeText->moveBy( m_scaleX * ( m_originalDmeTextCtr.x() - m_itemDmeText->boundingRect().width()  / 2.0 ),
+                           m_scaleY * ( m_originalDmeTextCtr.y() - m_itemDmeText->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemDmeText );
 
     updateView();
@@ -394,21 +394,21 @@ void qfi_NAV::reset()
     m_itemHdgText = 0;
     m_itemDmeText = 0;
 
-    m_heading    = 0.0f;
-    m_headingBug = 0.0f;
-    m_course     = 0.0f;
-    m_bearing    = 0.0f;
-    m_deviation  = 0.0f;
-    m_distance   = 0.0f;
+    m_heading    = 0.0;
+    m_headingBug = 0.0;
+    m_course     = 0.0;
+    m_bearing    = 0.0;
+    m_deviation  = 0.0;
+    m_distance   = 0.0;
 
     m_bearingVisible   = true;
     m_deviationVisible = true;
     m_distanceVisible  = true;
 
-    m_devBarDeltaX_new = 0.0f;
-    m_devBarDeltaX_old = 0.0f;
-    m_devBarDeltaY_new = 0.0f;
-    m_devBarDeltaY_old = 0.0f;
+    m_devBarDeltaX_new = 0.0;
+    m_devBarDeltaX_old = 0.0;
+    m_devBarDeltaY_new = 0.0;
+    m_devBarDeltaY_old = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -439,9 +439,9 @@ void qfi_NAV::updateView()
 
         double angle_deg = -m_heading + m_course;
 #       ifndef M_PI
-        double angle_rad = 3.14159265358979323846 * angle_deg / 180.0f;
+        double angle_rad = 3.14159265358979323846 * angle_deg / 180.0;
 #       else
-        double angle_rad = M_PI * angle_deg / 180.0f;
+        double angle_rad = M_PI * angle_deg / 180.0;
 #       endif
 
 
@@ -482,5 +482,5 @@ void qfi_NAV::updateView()
 
     m_scene->update();
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 }

--- a/src/qfi_NAV.cpp
+++ b/src/qfi_NAV.cpp
@@ -281,8 +281,8 @@ void qfi_NAV::resizeEvent( QResizeEvent *event )
 
 void qfi_NAV::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     m_itemBack = new QGraphicsSvgItem( ":/qfi/images/nav/nav_back.svg" );
     m_itemBack->setCacheMode( QGraphicsItem::NoCache );
@@ -415,8 +415,8 @@ void qfi_NAV::reset()
 
 void qfi_NAV::updateView()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     m_itemCrsArrow->setRotation( -m_heading + m_course );
     m_itemHdgBug->setRotation( -m_heading + m_headingBug );

--- a/src/qfi_NAV.h
+++ b/src/qfi_NAV.h
@@ -75,22 +75,22 @@ public:
     void update();
 
     /** @param heading [deg] */
-    void setHeading( float heading );
+    void setHeading( double heading );
 
     /** @param heading bug [deg] */
-    void setHeadingBug( float headingBug );
+    void setHeadingBug( double headingBug );
 
     /** @param course [deg] */
-    void setCourse( float course );
+    void setCourse( double course );
 
     /** @param bearing [deg] */
-    void setBearing( float bearing, bool visible = false );
+    void setBearing( double bearing, bool visible = false );
 
     /** @param deviation [-] */
-    void setDeviation( float deviation, bool visible = false );
+    void setDeviation( double deviation, bool visible = false );
 
     /** @param distance [nm] */
-    void setDistance( float distance, bool visible = false );
+    void setDistance( double distance, bool visible = false );
 
 protected:
 
@@ -124,26 +124,26 @@ private:
     QFont  m_hdgTextFont;
     QFont  m_dmeTextFont;
 
-    float m_heading;                    ///< [deg]
-    float m_headingBug;                 ///< [deg]
-    float m_course;
-    float m_bearing;
-    float m_deviation;
-    float m_distance;
+    double m_heading;                    ///< [deg]
+    double m_headingBug;                 ///< [deg]
+    double m_course;
+    double m_bearing;
+    double m_deviation;
+    double m_distance;
 
     bool m_bearingVisible;
     bool m_deviationVisible;
     bool m_distanceVisible;
 
-    float m_devBarDeltaX_new;
-    float m_devBarDeltaX_old;
-    float m_devBarDeltaY_new;
-    float m_devBarDeltaY_old;
+    double m_devBarDeltaX_new;
+    double m_devBarDeltaX_old;
+    double m_devBarDeltaY_new;
+    double m_devBarDeltaY_old;
 
-    float m_scaleX; ///<
-    float m_scaleY; ///<
+    double m_scaleX; ///<
+    double m_scaleY; ///<
 
-    float m_originalPixPerDev;
+    double m_originalPixPerDev;
 
     QPointF m_originalNavCtr;
 

--- a/src/qfi_PFD.cpp
+++ b/src/qfi_PFD.cpp
@@ -80,8 +80,8 @@ qfi_PFD::qfi_PFD( QWidget * parent ) :
     m_itemBack ( 0 ),
     m_itemMask ( 0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 300 ),
     m_originalWidth  ( 300 ),
@@ -183,7 +183,7 @@ void qfi_PFD::init()
     m_itemMask->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemMask );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -235,16 +235,16 @@ qfi_PFD::ADI::ADI( QGraphicsScene * scene ) :
     m_itemScaleH ( 0 ),
     m_itemScaleV ( 0 ),
 
-    m_roll          ( 0.0f ),
-    m_pitch         ( 0.0f ),
-    m_angleOfAttack ( 0.0f ),
-    m_sideslipAngle ( 0.0f ),
-    m_slipSkid      ( 0.0f ),
-    m_turnRate      ( 0.0f ),
-    m_barH          ( 0.0f ),
-    m_barV          ( 0.0f ),
-    m_dotH          ( 0.0f ),
-    m_dotV          ( 0.0f ),
+    m_roll          ( 0.0 ),
+    m_pitch         ( 0.0 ),
+    m_angleOfAttack ( 0.0 ),
+    m_sideslipAngle ( 0.0 ),
+    m_slipSkid      ( 0.0 ),
+    m_turnRate      ( 0.0 ),
+    m_barH          ( 0.0 ),
+    m_barV          ( 0.0 ),
+    m_dotH          ( 0.0 ),
+    m_dotV          ( 0.0 ),
 
     m_pathValid ( true ),
 
@@ -254,61 +254,61 @@ qfi_PFD::ADI::ADI( QGraphicsScene * scene ) :
     m_dotHVisible ( true ),
     m_dotVVisible ( true ),
 
-    m_laddDeltaX_new     ( 0.0f ),
-    m_laddDeltaX_old     ( 0.0f ),
-    m_laddBackDeltaX_new ( 0.0f ),
-    m_laddBackDeltaX_old ( 0.0f ),
-    m_laddBackDeltaY_new ( 0.0f ),
-    m_laddBackDeltaY_old ( 0.0f ),
-    m_laddDeltaY_new     ( 0.0f ),
-    m_laddDeltaY_old     ( 0.0f ),
-    m_slipDeltaX_new     ( 0.0f ),
-    m_slipDeltaX_old     ( 0.0f ),
-    m_slipDeltaY_new     ( 0.0f ),
-    m_slipDeltaY_old     ( 0.0f ),
-    m_turnDeltaX_new     ( 0.0f ),
-    m_turnDeltaX_old     ( 0.0f ),
-    m_pathDeltaX_new     ( 0.0f ),
-    m_pathDeltaX_old     ( 0.0f ),
-    m_pathDeltaY_new     ( 0.0f ),
-    m_pathDeltaY_old     ( 0.0f ),
-    m_markDeltaX_new     ( 0.0f ),
-    m_markDeltaX_old     ( 0.0f ),
-    m_markDeltaY_new     ( 0.0f ),
-    m_markDeltaY_old     ( 0.0f ),
-    m_barHDeltaX_new     ( 0.0f ),
-    m_barHDeltaX_old     ( 0.0f ),
-    m_barVDeltaY_new     ( 0.0f ),
-    m_barVDeltaY_old     ( 0.0f ),
-    m_dotHDeltaX_new     ( 0.0f ),
-    m_dotHDeltaX_old     ( 0.0f ),
-    m_dotVDeltaY_new     ( 0.0f ),
-    m_dotVDeltaY_old     ( 0.0f ),
+    m_laddDeltaX_new     ( 0.0 ),
+    m_laddDeltaX_old     ( 0.0 ),
+    m_laddBackDeltaX_new ( 0.0 ),
+    m_laddBackDeltaX_old ( 0.0 ),
+    m_laddBackDeltaY_new ( 0.0 ),
+    m_laddBackDeltaY_old ( 0.0 ),
+    m_laddDeltaY_new     ( 0.0 ),
+    m_laddDeltaY_old     ( 0.0 ),
+    m_slipDeltaX_new     ( 0.0 ),
+    m_slipDeltaX_old     ( 0.0 ),
+    m_slipDeltaY_new     ( 0.0 ),
+    m_slipDeltaY_old     ( 0.0 ),
+    m_turnDeltaX_new     ( 0.0 ),
+    m_turnDeltaX_old     ( 0.0 ),
+    m_pathDeltaX_new     ( 0.0 ),
+    m_pathDeltaX_old     ( 0.0 ),
+    m_pathDeltaY_new     ( 0.0 ),
+    m_pathDeltaY_old     ( 0.0 ),
+    m_markDeltaX_new     ( 0.0 ),
+    m_markDeltaX_old     ( 0.0 ),
+    m_markDeltaY_new     ( 0.0 ),
+    m_markDeltaY_old     ( 0.0 ),
+    m_barHDeltaX_new     ( 0.0 ),
+    m_barHDeltaX_old     ( 0.0 ),
+    m_barVDeltaY_new     ( 0.0 ),
+    m_barVDeltaY_old     ( 0.0 ),
+    m_dotHDeltaX_new     ( 0.0 ),
+    m_dotHDeltaX_old     ( 0.0 ),
+    m_dotVDeltaY_new     ( 0.0 ),
+    m_dotVDeltaY_old     ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalPixPerDeg (   3.0f ),
-    m_deltaLaddBack_max (  52.5f ),
-    m_deltaLaddBack_min ( -52.5f ),
-    m_maxSlipDeflection (  20.0f ),
-    m_maxTurnDeflection (  55.0f ),
-    m_maxBarsDeflection (  40.0f ),
-    m_maxDotsDeflection (  50.0f ),
+    m_originalPixPerDeg (   3.0 ),
+    m_deltaLaddBack_max (  52.5 ),
+    m_deltaLaddBack_min ( -52.5 ),
+    m_maxSlipDeflection (  20.0 ),
+    m_maxTurnDeflection (  55.0 ),
+    m_maxBarsDeflection (  40.0 ),
+    m_maxDotsDeflection (  50.0 ),
 
-    m_originalAdiCtr    ( 150.0f ,  125.0f ),
-    m_originalBackPos   (  45.0f ,  -85.0f ),
-    m_originalLaddPos   ( 110.0f , -175.0f ),
-    m_originalRollPos   (  45.0f ,   20.0f ),
-    m_originalSlipPos   ( 145.5f ,   68.5f ),
-    m_originalTurnPos   ( 142.5f ,  206.0f ),
-    m_originalPathPos   ( 135.0f ,  113.0f ),
-    m_originalBarHPos   ( 149.0f ,   85.0f ),
-    m_originalBarVPos   ( 110.0f ,  124.0f ),
-    m_originalDotHPos   ( 145.0f ,  188.0f ),
-    m_originalDotVPos   ( 213.0f ,  120.0f ),
-    m_originalScaleHPos (   0.0f ,    0.0f ),
-    m_originalScaleVPos (   0.0f ,    0.0f ),
+    m_originalAdiCtr    ( 150.0 ,  125.0 ),
+    m_originalBackPos   (  45.0 ,  -85.0 ),
+    m_originalLaddPos   ( 110.0 , -175.0 ),
+    m_originalRollPos   (  45.0 ,   20.0 ),
+    m_originalSlipPos   ( 145.5 ,   68.5 ),
+    m_originalTurnPos   ( 142.5 ,  206.0 ),
+    m_originalPathPos   ( 135.0 ,  113.0 ),
+    m_originalBarHPos   ( 149.0 ,   85.0 ),
+    m_originalBarVPos   ( 110.0 ,  124.0 ),
+    m_originalDotHPos   ( 145.0 ,  188.0 ),
+    m_originalDotVPos   ( 213.0 ,  120.0 ),
+    m_originalScaleHPos (   0.0 ,    0.0 ),
+    m_originalScaleVPos (   0.0 ,    0.0 ),
 
     m_backZ   ( 10 ),
     m_laddZ   ( 20 ),
@@ -446,7 +446,7 @@ void qfi_PFD::ADI::update( double scaleX, double scaleY )
 
     double delta  = m_originalPixPerDeg * m_pitch;
 
-    double roll_rad = M_PI * m_roll / 180.0f;
+    double roll_rad = M_PI * m_roll / 180.0;
 
     double sinRoll = sin( roll_rad );
     double cosRoll = cos( roll_rad );
@@ -483,8 +483,8 @@ void qfi_PFD::ADI::setRoll( double roll )
 {
     m_roll = roll;
 
-    if      ( m_roll < -180.0f ) m_roll = -180.0f;
-    else if ( m_roll >  180.0f ) m_roll =  180.0f;
+    if      ( m_roll < -180.0 ) m_roll = -180.0;
+    else if ( m_roll >  180.0 ) m_roll =  180.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -493,8 +493,8 @@ void qfi_PFD::ADI::setPitch( double pitch )
 {
     m_pitch = pitch;
 
-    if      ( m_pitch < -90.0f ) m_pitch = -90.0f;
-    else if ( m_pitch >  90.0f ) m_pitch =  90.0f;
+    if      ( m_pitch < -90.0 ) m_pitch = -90.0;
+    else if ( m_pitch >  90.0 ) m_pitch =  90.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -506,25 +506,25 @@ void qfi_PFD::ADI::setFlightPathMarker( double aoa, double sideslip, bool visibl
 
     m_pathValid = true;
 
-    if ( m_angleOfAttack < -15.0f )
+    if ( m_angleOfAttack < -15.0 )
     {
-        m_angleOfAttack = -15.0f;
+        m_angleOfAttack = -15.0;
         m_pathValid = false;
     }
-    else if ( m_angleOfAttack > 15.0f )
+    else if ( m_angleOfAttack > 15.0 )
     {
-        m_angleOfAttack = 15.0f;
+        m_angleOfAttack = 15.0;
         m_pathValid = false;
     }
 
-    if ( m_sideslipAngle < -10.0f )
+    if ( m_sideslipAngle < -10.0 )
     {
-        m_sideslipAngle = -10.0f;
+        m_sideslipAngle = -10.0;
         m_pathValid = false;
     }
-    else if ( m_sideslipAngle > 10.0f )
+    else if ( m_sideslipAngle > 10.0 )
     {
-        m_sideslipAngle = 10.0f;
+        m_sideslipAngle = 10.0;
         m_pathValid = false;
     }
 
@@ -537,8 +537,8 @@ void qfi_PFD::ADI::setSlipSkid( double slipSkid )
 {
     m_slipSkid = slipSkid;
 
-    if      ( m_slipSkid < -1.0f ) m_slipSkid = -1.0f;
-    else if ( m_slipSkid >  1.0f ) m_slipSkid =  1.0f;
+    if      ( m_slipSkid < -1.0 ) m_slipSkid = -1.0;
+    else if ( m_slipSkid >  1.0 ) m_slipSkid =  1.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -547,8 +547,8 @@ void qfi_PFD::ADI::setTurnRate( double turnRate )
 {
     m_turnRate = turnRate;
 
-    if      ( m_turnRate < -1.0f ) m_turnRate = -1.0f;
-    else if ( m_turnRate >  1.0f ) m_turnRate =  1.0f;
+    if      ( m_turnRate < -1.0 ) m_turnRate = -1.0;
+    else if ( m_turnRate >  1.0 ) m_turnRate =  1.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -557,8 +557,8 @@ void qfi_PFD::ADI::setBarH( double barH, bool visible )
 {
     m_barH = barH;
 
-    if      ( m_barH < -1.0f ) m_barH = -1.0f;
-    else if ( m_barH >  1.0f ) m_barH =  1.0f;
+    if      ( m_barH < -1.0 ) m_barH = -1.0;
+    else if ( m_barH >  1.0 ) m_barH =  1.0;
 
     m_barHVisible = visible;
 }
@@ -569,8 +569,8 @@ void qfi_PFD::ADI::setBarV( double barV, bool visible )
 {
     m_barV = barV;
 
-    if      ( m_barV < -1.0f ) m_barV = -1.0f;
-    else if ( m_barV >  1.0f ) m_barV =  1.0f;
+    if      ( m_barV < -1.0 ) m_barV = -1.0;
+    else if ( m_barV >  1.0 ) m_barV =  1.0;
 
     m_barVVisible = visible;
 }
@@ -581,8 +581,8 @@ void qfi_PFD::ADI::setDotH( double dotH, bool visible )
 {
     m_dotH = dotH;
 
-    if      ( m_dotH < -1.0f ) m_dotH = -1.0f;
-    else if ( m_dotH >  1.0f ) m_dotH =  1.0f;
+    if      ( m_dotH < -1.0 ) m_dotH = -1.0;
+    else if ( m_dotH >  1.0 ) m_dotH =  1.0;
 
     m_dotHVisible = visible;
 }
@@ -593,8 +593,8 @@ void qfi_PFD::ADI::setDotV( double dotV, bool visible )
 {
     m_dotV = dotV;
 
-    if      ( m_dotV < -1.0f ) m_dotV = -1.0f;
-    else if ( m_dotV >  1.0f ) m_dotV =  1.0f;
+    if      ( m_dotV < -1.0 ) m_dotV = -1.0;
+    else if ( m_dotV >  1.0 ) m_dotV =  1.0;
 
     m_dotVVisible = visible;
 }
@@ -618,16 +618,16 @@ void qfi_PFD::ADI::reset()
     m_itemScaleH = 0;
     m_itemScaleV = 0;
 
-    m_roll          = 0.0f;
-    m_pitch         = 0.0f;
-    m_angleOfAttack = 0.0f;
-    m_sideslipAngle = 0.0f;
-    m_slipSkid      = 0.0f;
-    m_turnRate      = 0.0f;
-    m_barH          = 0.0f;
-    m_barV          = 0.0f;
-    m_dotH          = 0.0f;
-    m_dotV          = 0.0f;
+    m_roll          = 0.0;
+    m_pitch         = 0.0;
+    m_angleOfAttack = 0.0;
+    m_sideslipAngle = 0.0;
+    m_slipSkid      = 0.0;
+    m_turnRate      = 0.0;
+    m_barH          = 0.0;
+    m_barV          = 0.0;
+    m_dotH          = 0.0;
+    m_dotV          = 0.0;
 
     m_pathValid = true;
 
@@ -637,36 +637,36 @@ void qfi_PFD::ADI::reset()
     m_dotHVisible = true;
     m_dotVVisible = true;
 
-    m_laddDeltaX_new     = 0.0f;
-    m_laddDeltaX_old     = 0.0f;
-    m_laddBackDeltaX_new = 0.0f;
-    m_laddBackDeltaX_old = 0.0f;
-    m_laddBackDeltaY_new = 0.0f;
-    m_laddBackDeltaY_old = 0.0f;
-    m_laddDeltaY_new     = 0.0f;
-    m_laddDeltaY_old     = 0.0f;
-    m_slipDeltaX_new     = 0.0f;
-    m_slipDeltaX_old     = 0.0f;
-    m_slipDeltaY_new     = 0.0f;
-    m_slipDeltaY_old     = 0.0f;
-    m_turnDeltaX_new     = 0.0f;
-    m_turnDeltaX_old     = 0.0f;
-    m_pathDeltaX_new     = 0.0f;
-    m_pathDeltaX_old     = 0.0f;
-    m_pathDeltaY_new     = 0.0f;
-    m_pathDeltaY_old     = 0.0f;
-    m_markDeltaX_new     = 0.0f;
-    m_markDeltaX_old     = 0.0f;
-    m_markDeltaY_new     = 0.0f;
-    m_markDeltaY_old     = 0.0f;
-    m_barHDeltaX_new     = 0.0f;
-    m_barHDeltaX_old     = 0.0f;
-    m_barVDeltaY_new     = 0.0f;
-    m_barVDeltaY_old     = 0.0f;
-    m_dotHDeltaX_new     = 0.0f;
-    m_dotHDeltaX_old     = 0.0f;
-    m_dotVDeltaY_new     = 0.0f;
-    m_dotVDeltaY_old     = 0.0f;
+    m_laddDeltaX_new     = 0.0;
+    m_laddDeltaX_old     = 0.0;
+    m_laddBackDeltaX_new = 0.0;
+    m_laddBackDeltaX_old = 0.0;
+    m_laddBackDeltaY_new = 0.0;
+    m_laddBackDeltaY_old = 0.0;
+    m_laddDeltaY_new     = 0.0;
+    m_laddDeltaY_old     = 0.0;
+    m_slipDeltaX_new     = 0.0;
+    m_slipDeltaX_old     = 0.0;
+    m_slipDeltaY_new     = 0.0;
+    m_slipDeltaY_old     = 0.0;
+    m_turnDeltaX_new     = 0.0;
+    m_turnDeltaX_old     = 0.0;
+    m_pathDeltaX_new     = 0.0;
+    m_pathDeltaX_old     = 0.0;
+    m_pathDeltaY_new     = 0.0;
+    m_pathDeltaY_old     = 0.0;
+    m_markDeltaX_new     = 0.0;
+    m_markDeltaX_old     = 0.0;
+    m_markDeltaY_new     = 0.0;
+    m_markDeltaY_old     = 0.0;
+    m_barHDeltaX_new     = 0.0;
+    m_barHDeltaX_old     = 0.0;
+    m_barVDeltaY_new     = 0.0;
+    m_barVDeltaY_old     = 0.0;
+    m_dotHDeltaX_new     = 0.0;
+    m_dotHDeltaX_old     = 0.0;
+    m_dotVDeltaY_new     = 0.0;
+    m_dotVDeltaY_old     = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -789,7 +789,7 @@ void qfi_PFD::ADI::updateBars()
 
         m_barVDeltaY_new = m_scaleY * m_maxBarsDeflection * m_barV;
 
-        m_itemBarV->moveBy( 0.0f, m_barVDeltaY_old - m_barVDeltaY_new );
+        m_itemBarV->moveBy( 0.0, m_barVDeltaY_old - m_barVDeltaY_new );
     }
     else
     {
@@ -803,7 +803,7 @@ void qfi_PFD::ADI::updateBars()
 
         m_barHDeltaX_new = m_scaleX * m_maxBarsDeflection * m_barH;
 
-        m_itemBarH->moveBy( m_barHDeltaX_new - m_barHDeltaX_old, 0.0f );
+        m_itemBarH->moveBy( m_barHDeltaX_new - m_barHDeltaX_old, 0.0 );
     }
     else
     {
@@ -823,7 +823,7 @@ void qfi_PFD::ADI::updateDots()
 
         m_dotHDeltaX_new = m_scaleX * m_maxDotsDeflection * m_dotH;
 
-        m_itemDotH->moveBy( m_dotHDeltaX_new - m_dotHDeltaX_old, 0.0f );
+        m_itemDotH->moveBy( m_dotHDeltaX_new - m_dotHDeltaX_old, 0.0 );
     }
     else
     {
@@ -840,7 +840,7 @@ void qfi_PFD::ADI::updateDots()
 
         m_dotVDeltaY_new = m_scaleY * m_maxDotsDeflection * m_dotV;
 
-        m_itemDotV->moveBy( 0.0f, m_dotVDeltaY_old - m_dotVDeltaY_new );
+        m_itemDotV->moveBy( 0.0, m_dotVDeltaY_old - m_dotVDeltaY_new );
     }
     else
     {
@@ -873,37 +873,37 @@ qfi_PFD::ALT::ALT( QGraphicsScene * scene ) :
     m_pressTextColor (   0, 255,   0 ),
     m_labelsColor    ( 255, 255, 255 ),
 
-    m_altitude ( 0.0f ),
-    m_pressure ( 0.0f ),
+    m_altitude ( 0.0 ),
+    m_pressure ( 0.0 ),
 
     m_pressureUnit ( 0 ),
 
-    m_scale1DeltaY_new ( 0.0f ),
-    m_scale1DeltaY_old ( 0.0f ),
-    m_scale2DeltaY_new ( 0.0f ),
-    m_scale2DeltaY_old ( 0.0f ),
-    m_groundDeltaY_new ( 0.0f ),
-    m_groundDeltaY_old ( 0.0f ),
-    m_labelsDeltaY_new ( 0.0f ),
-    m_labelsDeltaY_old ( 0.0f ),
+    m_scale1DeltaY_new ( 0.0 ),
+    m_scale1DeltaY_old ( 0.0 ),
+    m_scale2DeltaY_new ( 0.0 ),
+    m_scale2DeltaY_old ( 0.0 ),
+    m_groundDeltaY_new ( 0.0 ),
+    m_groundDeltaY_old ( 0.0 ),
+    m_labelsDeltaY_new ( 0.0 ),
+    m_labelsDeltaY_old ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalPixPerAlt   ( 0.150f ),
-    m_originalScaleHeight ( 300.0f ),
-    m_originalLabelsX     ( 250.0f ),
-    m_originalLabel1Y     (  50.0f ),
-    m_originalLabel2Y     ( 125.0f ),
-    m_originalLabel3Y     ( 200.0f ),
+    m_originalPixPerAlt   ( 0.150 ),
+    m_originalScaleHeight ( 300.0 ),
+    m_originalLabelsX     ( 250.0 ),
+    m_originalLabel1Y     (  50.0 ),
+    m_originalLabel2Y     ( 125.0 ),
+    m_originalLabel3Y     ( 200.0 ),
 
-    m_originalBackPos     ( 231.0f ,   37.5f ),
-    m_originalScale1Pos   ( 231.0f , -174.5f ),
-    m_originalScale2Pos   ( 231.0f , -474.5f ),
-    m_originalGroundPos   ( 231.5f ,  124.5f ),
-    m_originalFramePos    ( 225.0f ,  110.0f ),
-    m_originalAltitudeCtr ( 254.0f ,  126.0f ),
-    m_originalPressureCtr ( 254.0f ,  225.0f ),
+    m_originalBackPos     ( 231.0 ,   37.5 ),
+    m_originalScale1Pos   ( 231.0 , -174.5 ),
+    m_originalScale2Pos   ( 231.0 , -474.5 ),
+    m_originalGroundPos   ( 231.5 ,  124.5 ),
+    m_originalFramePos    ( 225.0 ,  110.0 ),
+    m_originalAltitudeCtr ( 254.0 ,  126.0 ),
+    m_originalPressureCtr ( 254.0 ,  225.0 ),
 
     m_backZ      (  70 ),
     m_scaleZ     (  77 ),
@@ -914,22 +914,22 @@ qfi_PFD::ALT::ALT( QGraphicsScene * scene ) :
 {
 #   ifdef WIN32
     m_frameTextFont.setFamily( "Courier" );
-    m_frameTextFont.setPointSizeF( 9.0f );
+    m_frameTextFont.setPointSizeF( 9.0 );
     m_frameTextFont.setStretch( QFont::Condensed );
     m_frameTextFont.setWeight( QFont::Bold );
 
     m_labelsFont.setFamily( "Courier" );
-    m_labelsFont.setPointSizeF( 7.0f );
+    m_labelsFont.setPointSizeF( 7.0 );
     m_labelsFont.setStretch( QFont::Condensed );
     m_labelsFont.setWeight( QFont::Bold );
 #   else
     m_frameTextFont.setFamily( "Courier" );
-    m_frameTextFont.setPointSizeF( 10.0f );
+    m_frameTextFont.setPointSizeF( 10.0 );
     m_frameTextFont.setStretch( QFont::Condensed );
     m_frameTextFont.setWeight( QFont::Bold );
 
     m_labelsFont.setFamily( "Courier" );
-    m_labelsFont.setPointSizeF( 8.0f );
+    m_labelsFont.setPointSizeF( 8.0 );
     m_labelsFont.setStretch( QFont::Condensed );
     m_labelsFont.setWeight( QFont::Bold );
 #   endif
@@ -973,8 +973,8 @@ void qfi_PFD::ALT::init( double scaleX, double scaleY )
     m_itemLabel1->setDefaultTextColor( m_labelsColor );
     m_itemLabel1->setFont( m_labelsFont );
     m_itemLabel1->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel1->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel1->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel1Y - m_itemLabel1->boundingRect().height() / 2.0f ) );
+    m_itemLabel1->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel1->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel1Y - m_itemLabel1->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel1 );
 
     m_itemLabel2 = new QGraphicsTextItem( QString( "99999" ) );
@@ -983,8 +983,8 @@ void qfi_PFD::ALT::init( double scaleX, double scaleY )
     m_itemLabel2->setDefaultTextColor( m_labelsColor );
     m_itemLabel2->setFont( m_labelsFont );
     m_itemLabel2->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel2->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel2->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel2Y - m_itemLabel2->boundingRect().height() / 2.0f ) );
+    m_itemLabel2->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel2->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel2Y - m_itemLabel2->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel2 );
 
     m_itemLabel3 = new QGraphicsTextItem( QString( "99999" ) );
@@ -993,8 +993,8 @@ void qfi_PFD::ALT::init( double scaleX, double scaleY )
     m_itemLabel3->setDefaultTextColor( m_labelsColor );
     m_itemLabel3->setFont( m_labelsFont );
     m_itemLabel3->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel3->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel3->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel3Y - m_itemLabel3->boundingRect().height() / 2.0f ) );
+    m_itemLabel3->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel3->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel3Y - m_itemLabel3->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel3 );
 
     m_itemGround = new QGraphicsSvgItem( ":/qfi/images/pfd/pfd_alt_ground.svg" );
@@ -1017,8 +1017,8 @@ void qfi_PFD::ALT::init( double scaleX, double scaleY )
     m_itemAltitude->setDefaultTextColor( m_frameTextColor );
     m_itemAltitude->setFont( m_frameTextFont );
     m_itemAltitude->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemAltitude->moveBy( m_scaleX * ( m_originalAltitudeCtr.x() - m_itemAltitude->boundingRect().width()  / 2.0f ),
-                           m_scaleY * ( m_originalAltitudeCtr.y() - m_itemAltitude->boundingRect().height() / 2.0f ) );
+    m_itemAltitude->moveBy( m_scaleX * ( m_originalAltitudeCtr.x() - m_itemAltitude->boundingRect().width()  / 2.0 ),
+                           m_scaleY * ( m_originalAltitudeCtr.y() - m_itemAltitude->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemAltitude );
 
     m_itemPressure = new QGraphicsTextItem( QString( "  STD  " ) );
@@ -1027,8 +1027,8 @@ void qfi_PFD::ALT::init( double scaleX, double scaleY )
     m_itemPressure->setDefaultTextColor( m_pressTextColor );
     m_itemPressure->setFont( m_frameTextFont );
     m_itemPressure->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemPressure->moveBy( m_scaleX * ( m_originalPressureCtr.x() - m_itemPressure->boundingRect().width()  / 2.0f ),
-                           m_scaleY * ( m_originalPressureCtr.y() - m_itemPressure->boundingRect().height() / 2.0f ) );
+    m_itemPressure->moveBy( m_scaleX * ( m_originalPressureCtr.x() - m_itemPressure->boundingRect().width()  / 2.0 ),
+                           m_scaleY * ( m_originalPressureCtr.y() - m_itemPressure->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemPressure );
 
     update( scaleX, scaleY );
@@ -1057,8 +1057,8 @@ void qfi_PFD::ALT::setAltitude( double altitude )
 {
     m_altitude = altitude;
 
-    if      ( m_altitude <     0.0f ) m_altitude =     0.0f;
-    else if ( m_altitude > 99999.0f ) m_altitude = 99999.0f;
+    if      ( m_altitude <     0.0 ) m_altitude =     0.0;
+    else if ( m_altitude > 99999.0 ) m_altitude = 99999.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1067,8 +1067,8 @@ void qfi_PFD::ALT::setPressure( double pressure, int pressureUnit )
 {
     m_pressure = pressure;
 
-    if      ( m_pressure <    0.0f ) m_pressure =    0.0f;
-    else if ( m_pressure > 2000.0f ) m_pressure = 2000.0f;
+    if      ( m_pressure <    0.0 ) m_pressure =    0.0;
+    else if ( m_pressure > 2000.0 ) m_pressure = 2000.0;
 
     m_pressureUnit = 0;
 
@@ -1091,19 +1091,19 @@ void qfi_PFD::ALT::reset()
     m_itemAltitude = 0;
     m_itemPressure = 0;
 
-    m_altitude = 0.0f;
-    m_pressure = 0.0f;
+    m_altitude = 0.0;
+    m_pressure = 0.0;
 
     m_pressureUnit = 0;
 
-    m_scale1DeltaY_new = 0.0f;
-    m_scale1DeltaY_old = 0.0f;
-    m_scale2DeltaY_new = 0.0f;
-    m_scale2DeltaY_old = 0.0f;
-    m_groundDeltaY_new = 0.0f;
-    m_groundDeltaY_old = 0.0f;
-    m_labelsDeltaY_new = 0.0f;
-    m_labelsDeltaY_old = 0.0f;
+    m_scale1DeltaY_new = 0.0;
+    m_scale1DeltaY_old = 0.0;
+    m_scale2DeltaY_new = 0.0;
+    m_scale2DeltaY_old = 0.0;
+    m_groundDeltaY_new = 0.0;
+    m_groundDeltaY_old = 0.0;
+    m_labelsDeltaY_new = 0.0;
+    m_labelsDeltaY_old = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1143,55 +1143,55 @@ void qfi_PFD::ALT::updateScale()
     m_groundDeltaY_new = m_scale1DeltaY_new;
 
     double scaleSingleHeight = m_scaleY * m_originalScaleHeight;
-    double scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0f;
+    double scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0;
 
-    while ( m_scale1DeltaY_new > scaleSingleHeight + m_scaleY * 74.5f )
+    while ( m_scale1DeltaY_new > scaleSingleHeight + m_scaleY * 74.5 )
     {
         m_scale1DeltaY_new = m_scale1DeltaY_new - scaleDoubleHeight;
     }
 
-    while ( m_scale2DeltaY_new > scaleDoubleHeight + m_scaleY * 74.5f )
+    while ( m_scale2DeltaY_new > scaleDoubleHeight + m_scaleY * 74.5 )
     {
         m_scale2DeltaY_new = m_scale2DeltaY_new - scaleDoubleHeight;
     }
 
-    if ( m_groundDeltaY_new > m_scaleY * 100.0f ) m_groundDeltaY_new = m_scaleY * 100.0f;
+    if ( m_groundDeltaY_new > m_scaleY * 100.0 ) m_groundDeltaY_new = m_scaleY * 100.0;
 
-    m_itemScale1->moveBy( 0.0f, m_scale1DeltaY_new - m_scale1DeltaY_old );
-    m_itemScale2->moveBy( 0.0f, m_scale2DeltaY_new - m_scale2DeltaY_old );
-    m_itemGround->moveBy( 0.0f, m_groundDeltaY_new - m_groundDeltaY_old );
+    m_itemScale1->moveBy( 0.0, m_scale1DeltaY_new - m_scale1DeltaY_old );
+    m_itemScale2->moveBy( 0.0, m_scale2DeltaY_new - m_scale2DeltaY_old );
+    m_itemGround->moveBy( 0.0, m_groundDeltaY_new - m_groundDeltaY_old );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void qfi_PFD::ALT::updateScaleLabels()
 {
-    int tmp = floor( m_altitude + 0.5f );
+    int tmp = floor( m_altitude + 0.5 );
     int alt = tmp - ( tmp % 500 );
 
-    double alt1 = static_cast<double>(alt) + 500.0f;
+    double alt1 = static_cast<double>(alt) + 500.0;
     double alt2 = static_cast<double>(alt);
-    double alt3 = static_cast<double>(alt) - 500.0f;
+    double alt3 = static_cast<double>(alt) - 500.0;
 
     m_labelsDeltaY_new = m_scaleY * m_originalPixPerAlt * m_altitude;
 
-    while ( m_labelsDeltaY_new > m_scaleY * 37.5f )
+    while ( m_labelsDeltaY_new > m_scaleY * 37.5 )
     {
-        m_labelsDeltaY_new = m_labelsDeltaY_new - m_scaleY * 75.0f;
+        m_labelsDeltaY_new = m_labelsDeltaY_new - m_scaleY * 75.0;
     }
 
-    if ( m_labelsDeltaY_new < 0.0f && m_altitude > alt2 )
+    if ( m_labelsDeltaY_new < 0.0 && m_altitude > alt2 )
     {
-        alt1 += 500.0f;
-        alt2 += 500.0f;
-        alt3 += 500.0f;
+        alt1 += 500.0;
+        alt2 += 500.0;
+        alt3 += 500.0;
     }
 
-    m_itemLabel1->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel2->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel3->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel1->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel2->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel3->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
 
-    if ( alt1 > 0.0f && alt1 <= 100000.0f )
+    if ( alt1 > 0.0 && alt1 <= 100000.0 )
     {
         m_itemLabel1->setVisible( true );
         m_itemLabel1->setPlainText( QString("%1").arg(alt1, 5, 'f', 0, QChar(' ')) );
@@ -1201,7 +1201,7 @@ void qfi_PFD::ALT::updateScaleLabels()
         m_itemLabel1->setVisible( false );
     }
 
-    if ( alt2 > 0.0f && alt2 <= 100000.0f )
+    if ( alt2 > 0.0 && alt2 <= 100000.0 )
     {
         m_itemLabel2->setVisible( true );
         m_itemLabel2->setPlainText( QString("%1").arg(alt2, 5, 'f', 0, QChar(' ')) );
@@ -1211,7 +1211,7 @@ void qfi_PFD::ALT::updateScaleLabels()
         m_itemLabel2->setVisible( false );
     }
 
-    if ( alt3 > 0.0f && alt3 <= 100000.0f )
+    if ( alt3 > 0.0 && alt3 <= 100000.0 )
     {
         m_itemLabel3->setVisible( true );
         m_itemLabel3->setPlainText( QString("%1").arg(alt3, 5, 'f', 0, QChar(' ')) );
@@ -1246,36 +1246,36 @@ qfi_PFD::ASI::ASI( QGraphicsScene * scene ) :
     m_frameTextColor ( 255, 255, 255 ),
     m_labelsColor    ( 255, 255, 255 ),
 
-    m_airspeed ( 0.0f ),
-    m_machNo   ( 0.0f ),
+    m_airspeed ( 0.0 ),
+    m_machNo   ( 0.0 ),
 
-    m_scale1DeltaY_new ( 0.0f ),
-    m_scale1DeltaY_old ( 0.0f ),
-    m_scale2DeltaY_new ( 0.0f ),
-    m_scale2DeltaY_old ( 0.0f ),
-    m_labelsDeltaY_new ( 0.0f ),
-    m_labelsDeltaY_old ( 0.0f ),
+    m_scale1DeltaY_new ( 0.0 ),
+    m_scale1DeltaY_old ( 0.0 ),
+    m_scale2DeltaY_new ( 0.0 ),
+    m_scale2DeltaY_old ( 0.0 ),
+    m_labelsDeltaY_new ( 0.0 ),
+    m_labelsDeltaY_old ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalPixPerSpd   (   1.5f ),
-    m_originalScaleHeight ( 300.0f ),
-    m_originalLabelsX     (  43.0f ),
-    m_originalLabel1Y     (  35.0f ),
-    m_originalLabel2Y     (  65.0f ),
-    m_originalLabel3Y     (  95.0f ),
-    m_originalLabel4Y     ( 125.0f ),
-    m_originalLabel5Y     ( 155.0f ),
-    m_originalLabel6Y     ( 185.0f ),
-    m_originalLabel7Y     ( 215.0f ),
+    m_originalPixPerSpd   (   1.5 ),
+    m_originalScaleHeight ( 300.0 ),
+    m_originalLabelsX     (  43.0 ),
+    m_originalLabel1Y     (  35.0 ),
+    m_originalLabel2Y     (  65.0 ),
+    m_originalLabel3Y     (  95.0 ),
+    m_originalLabel4Y     ( 125.0 ),
+    m_originalLabel5Y     ( 155.0 ),
+    m_originalLabel6Y     ( 185.0 ),
+    m_originalLabel7Y     ( 215.0 ),
 
-    m_originalBackPos     ( 25.0f ,   37.5f ),
-    m_originalScale1Pos   ( 56.0f , -174.5f ),
-    m_originalScale2Pos   ( 56.0f , -474.5f ),
-    m_originalFramePos    (  0.0f ,  110.0f ),
-    m_originalAirspeedCtr ( 40.0f ,  126.0f ),
-    m_originalMachNoCtr   ( 43.0f ,  225.0f ),
+    m_originalBackPos     ( 25.0 ,   37.5 ),
+    m_originalScale1Pos   ( 56.0 , -174.5 ),
+    m_originalScale2Pos   ( 56.0 , -474.5 ),
+    m_originalFramePos    (  0.0 ,  110.0 ),
+    m_originalAirspeedCtr ( 40.0 ,  126.0 ),
+    m_originalMachNoCtr   ( 43.0 ,  225.0 ),
 
     m_backZ      (  70 ),
     m_scaleZ     (  80 ),
@@ -1285,22 +1285,22 @@ qfi_PFD::ASI::ASI( QGraphicsScene * scene ) :
 {
 #   ifdef WIN32
     m_frameTextFont.setFamily( "Courier" );
-    m_frameTextFont.setPointSizeF( 9.0f );
+    m_frameTextFont.setPointSizeF( 9.0 );
     m_frameTextFont.setStretch( QFont::Condensed );
     m_frameTextFont.setWeight( QFont::Bold );
 
     m_labelsFont.setFamily( "Courier" );
-    m_labelsFont.setPointSizeF( 7.0f );
+    m_labelsFont.setPointSizeF( 7.0 );
     m_labelsFont.setStretch( QFont::Condensed );
     m_labelsFont.setWeight( QFont::Bold );
 #   else
     m_frameTextFont.setFamily( "Courier" );
-    m_frameTextFont.setPointSizeF( 10.0f );
+    m_frameTextFont.setPointSizeF( 10.0 );
     m_frameTextFont.setStretch( QFont::Condensed );
     m_frameTextFont.setWeight( QFont::Bold );
 
     m_labelsFont.setFamily( "Courier" );
-    m_labelsFont.setPointSizeF( 8.0f );
+    m_labelsFont.setPointSizeF( 8.0 );
     m_labelsFont.setStretch( QFont::Condensed );
     m_labelsFont.setWeight( QFont::Bold );
 #   endif
@@ -1344,8 +1344,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel1->setDefaultTextColor( m_labelsColor );
     m_itemLabel1->setFont( m_labelsFont );
     m_itemLabel1->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel1->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel1->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel1Y - m_itemLabel1->boundingRect().height() / 2.0f ) );
+    m_itemLabel1->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel1->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel1Y - m_itemLabel1->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel1 );
 
     m_itemLabel2 = new QGraphicsTextItem( QString( "999" ) );
@@ -1354,8 +1354,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel2->setDefaultTextColor( m_labelsColor );
     m_itemLabel2->setFont( m_labelsFont );
     m_itemLabel2->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel2->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel2->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel2Y - m_itemLabel2->boundingRect().height() / 2.0f ) );
+    m_itemLabel2->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel2->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel2Y - m_itemLabel2->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel2 );
 
     m_itemLabel3 = new QGraphicsTextItem( QString( "999" ) );
@@ -1364,8 +1364,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel3->setDefaultTextColor( m_labelsColor );
     m_itemLabel3->setFont( m_labelsFont );
     m_itemLabel3->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel3->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel3->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel3Y - m_itemLabel3->boundingRect().height() / 2.0f ) );
+    m_itemLabel3->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel3->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel3Y - m_itemLabel3->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel3 );
 
     m_itemLabel4 = new QGraphicsTextItem( QString( "999" ) );
@@ -1374,8 +1374,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel4->setDefaultTextColor( m_labelsColor );
     m_itemLabel4->setFont( m_labelsFont );
     m_itemLabel4->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel4->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel4->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel4Y - m_itemLabel4->boundingRect().height() / 2.0f ) );
+    m_itemLabel4->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel4->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel4Y - m_itemLabel4->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel4 );
 
     m_itemLabel5 = new QGraphicsTextItem( QString( "999" ) );
@@ -1384,8 +1384,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel5->setDefaultTextColor( m_labelsColor );
     m_itemLabel5->setFont( m_labelsFont );
     m_itemLabel5->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel5->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel5->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel5Y - m_itemLabel5->boundingRect().height() / 2.0f ) );
+    m_itemLabel5->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel5->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel5Y - m_itemLabel5->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel5 );
 
     m_itemLabel6 = new QGraphicsTextItem( QString( "999" ) );
@@ -1394,8 +1394,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel6->setDefaultTextColor( m_labelsColor );
     m_itemLabel6->setFont( m_labelsFont );
     m_itemLabel6->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel6->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel6->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel6Y - m_itemLabel6->boundingRect().height() / 2.0f ) );
+    m_itemLabel6->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel6->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel6Y - m_itemLabel6->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel6 );
 
     m_itemLabel7 = new QGraphicsTextItem( QString( "999" ) );
@@ -1404,8 +1404,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemLabel7->setDefaultTextColor( m_labelsColor );
     m_itemLabel7->setFont( m_labelsFont );
     m_itemLabel7->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemLabel7->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel7->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalLabel7Y - m_itemLabel7->boundingRect().height() / 2.0f ) );
+    m_itemLabel7->moveBy( m_scaleX * ( m_originalLabelsX - m_itemLabel7->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalLabel7Y - m_itemLabel7->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemLabel7 );
 
     m_itemFrame = new QGraphicsSvgItem( ":/qfi/images/pfd/pfd_asi_frame.svg" );
@@ -1422,8 +1422,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemAirspeed->setDefaultTextColor( m_frameTextColor );
     m_itemAirspeed->setFont( m_frameTextFont );
     m_itemAirspeed->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemAirspeed->moveBy( m_scaleX * ( m_originalAirspeedCtr.x() - m_itemAirspeed->boundingRect().width()  / 2.0f ),
-                           m_scaleY * ( m_originalAirspeedCtr.y() - m_itemAirspeed->boundingRect().height() / 2.0f ) );
+    m_itemAirspeed->moveBy( m_scaleX * ( m_originalAirspeedCtr.x() - m_itemAirspeed->boundingRect().width()  / 2.0 ),
+                           m_scaleY * ( m_originalAirspeedCtr.y() - m_itemAirspeed->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemAirspeed );
 
     m_itemMachNo = new QGraphicsTextItem( QString( ".000" ) );
@@ -1433,8 +1433,8 @@ void qfi_PFD::ASI::init( double scaleX, double scaleY )
     m_itemMachNo->setDefaultTextColor( m_frameTextColor );
     m_itemMachNo->setFont( m_frameTextFont );
     m_itemMachNo->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemMachNo->moveBy( m_scaleX * ( m_originalMachNoCtr.x() - m_itemMachNo->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalMachNoCtr.y() - m_itemMachNo->boundingRect().height() / 2.0f ) );
+    m_itemMachNo->moveBy( m_scaleX * ( m_originalMachNoCtr.x() - m_itemMachNo->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalMachNoCtr.y() - m_itemMachNo->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemMachNo );
 
     update( scaleX, scaleY );
@@ -1460,8 +1460,8 @@ void qfi_PFD::ASI::setAirspeed( double airspeed )
 {
     m_airspeed = airspeed;
 
-    if      ( m_airspeed <    0.0f ) m_airspeed =    0.0f;
-    else if ( m_airspeed > 9999.0f ) m_airspeed = 9999.0f;
+    if      ( m_airspeed <    0.0 ) m_airspeed =    0.0;
+    else if ( m_airspeed > 9999.0 ) m_airspeed = 9999.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1470,8 +1470,8 @@ void qfi_PFD::ASI::setMachNo( double machNo )
 {
     m_machNo = machNo;
 
-    if      ( m_machNo <  0.0f ) m_machNo =  0.0f;
-    else if ( m_machNo > 99.9f ) m_machNo = 99.9f;
+    if      ( m_machNo <  0.0 ) m_machNo =  0.0;
+    else if ( m_machNo > 99.9 ) m_machNo = 99.9;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1492,15 +1492,15 @@ void qfi_PFD::ASI::reset()
     m_itemAirspeed = 0;
     m_itemMachNo   = 0;
 
-    m_airspeed = 0.0f;
-    m_machNo   = 0.0f;
+    m_airspeed = 0.0;
+    m_machNo   = 0.0;
 
-    m_scale1DeltaY_new = 0.0f;
-    m_scale1DeltaY_old = 0.0f;
-    m_scale2DeltaY_new = 0.0f;
-    m_scale2DeltaY_old = 0.0f;
-    m_labelsDeltaY_new = 0.0f;
-    m_labelsDeltaY_old = 0.0f;
+    m_scale1DeltaY_new = 0.0;
+    m_scale1DeltaY_old = 0.0;
+    m_scale2DeltaY_new = 0.0;
+    m_scale2DeltaY_old = 0.0;
+    m_labelsDeltaY_new = 0.0;
+    m_labelsDeltaY_old = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1509,14 +1509,14 @@ void qfi_PFD::ASI::updateAirspeed()
 {
     m_itemAirspeed->setPlainText( QString("%1").arg(m_airspeed, 3, 'f', 0, QChar('0')) );
 
-    if ( m_machNo < 1.0f )
+    if ( m_machNo < 1.0 )
     {
-        double machNo = 1000.0f * m_machNo;
+        double machNo = 1000.0 * m_machNo;
         m_itemMachNo->setPlainText( QString(".%1").arg(machNo, 3, 'f', 0, QChar('0')) );
     }
     else
     {
-        if ( m_machNo < 10.0f )
+        if ( m_machNo < 10.0 )
         {
             m_itemMachNo->setPlainText( QString::number( m_machNo, 'f', 2 ) );
         }
@@ -1538,20 +1538,20 @@ void qfi_PFD::ASI::updateScale()
     m_scale2DeltaY_new = m_scale1DeltaY_new;
 
     double scaleSingleHeight = m_scaleY * m_originalScaleHeight;
-    double scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0f;
+    double scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0;
 
-    while ( m_scale1DeltaY_new > scaleSingleHeight + m_scaleY * 74.5f )
+    while ( m_scale1DeltaY_new > scaleSingleHeight + m_scaleY * 74.5 )
     {
         m_scale1DeltaY_new = m_scale1DeltaY_new - scaleDoubleHeight;
     }
 
-    while ( m_scale2DeltaY_new > scaleDoubleHeight + m_scaleY * 74.5f )
+    while ( m_scale2DeltaY_new > scaleDoubleHeight + m_scaleY * 74.5 )
     {
         m_scale2DeltaY_new = m_scale2DeltaY_new - scaleDoubleHeight;
     }
 
-    m_itemScale1->moveBy( 0.0f, m_scale1DeltaY_new - m_scale1DeltaY_old );
-    m_itemScale2->moveBy( 0.0f, m_scale2DeltaY_new - m_scale2DeltaY_old );
+    m_itemScale1->moveBy( 0.0, m_scale1DeltaY_new - m_scale1DeltaY_old );
+    m_itemScale2->moveBy( 0.0, m_scale2DeltaY_new - m_scale2DeltaY_old );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1560,42 +1560,42 @@ void qfi_PFD::ASI::updateScaleLabels()
 {
     m_labelsDeltaY_new = m_scaleY * m_originalPixPerSpd * m_airspeed;
 
-    int tmp = floor( m_airspeed + 0.5f );
+    int tmp = floor( m_airspeed + 0.5 );
     int spd = tmp - ( tmp % 20 );
 
-    double spd1 = static_cast<double>(spd) + 60.0f;
-    double spd2 = static_cast<double>(spd) + 40.0f;
-    double spd3 = static_cast<double>(spd) + 20.0f;
+    double spd1 = static_cast<double>(spd) + 60.0;
+    double spd2 = static_cast<double>(spd) + 40.0;
+    double spd3 = static_cast<double>(spd) + 20.0;
     double spd4 = static_cast<double>(spd);
-    double spd5 = static_cast<double>(spd) - 20.0f;
-    double spd6 = static_cast<double>(spd) - 40.0f;
-    double spd7 = static_cast<double>(spd) - 60.0f;
+    double spd5 = static_cast<double>(spd) - 20.0;
+    double spd6 = static_cast<double>(spd) - 40.0;
+    double spd7 = static_cast<double>(spd) - 60.0;
 
-    while ( m_labelsDeltaY_new > m_scaleY * 15.0f )
+    while ( m_labelsDeltaY_new > m_scaleY * 15.0 )
     {
-        m_labelsDeltaY_new = m_labelsDeltaY_new - m_scaleY * 30.0f;
+        m_labelsDeltaY_new = m_labelsDeltaY_new - m_scaleY * 30.0;
     }
 
     if ( m_labelsDeltaY_new < 0.0 && m_airspeed > spd4 )
     {
-        spd1 += 20.0f;
-        spd2 += 20.0f;
-        spd3 += 20.0f;
-        spd4 += 20.0f;
-        spd5 += 20.0f;
-        spd6 += 20.0f;
-        spd7 += 20.0f;
+        spd1 += 20.0;
+        spd2 += 20.0;
+        spd3 += 20.0;
+        spd4 += 20.0;
+        spd5 += 20.0;
+        spd6 += 20.0;
+        spd7 += 20.0;
     }
 
-    m_itemLabel1->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel2->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel3->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel4->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel5->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel6->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
-    m_itemLabel7->moveBy( 0.0f, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel1->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel2->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel3->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel4->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel5->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel6->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
+    m_itemLabel7->moveBy( 0.0, m_labelsDeltaY_new - m_labelsDeltaY_old );
 
-    if ( spd1 >= 0.0f && spd1 <= 10000.0f )
+    if ( spd1 >= 0.0 && spd1 <= 10000.0 )
     {
         m_itemLabel1->setVisible( true );
         m_itemLabel1->setPlainText( QString("%1").arg(spd1, 3, 'f', 0, QChar(' ')) );
@@ -1605,7 +1605,7 @@ void qfi_PFD::ASI::updateScaleLabels()
         m_itemLabel1->setVisible( false );
     }
 
-    if ( spd2 >= 0.0f && spd2 <= 10000.0f )
+    if ( spd2 >= 0.0 && spd2 <= 10000.0 )
     {
         m_itemLabel2->setVisible( true );
         m_itemLabel2->setPlainText( QString("%1").arg(spd2, 3, 'f', 0, QChar(' ')) );
@@ -1615,7 +1615,7 @@ void qfi_PFD::ASI::updateScaleLabels()
         m_itemLabel2->setVisible( false );
     }
 
-    if ( spd3 >= 0.0f && spd3 <= 10000.0f )
+    if ( spd3 >= 0.0 && spd3 <= 10000.0 )
     {
         m_itemLabel3->setVisible( true );
         m_itemLabel3->setPlainText( QString("%1").arg(spd3, 3, 'f', 0, QChar(' ')) );
@@ -1625,7 +1625,7 @@ void qfi_PFD::ASI::updateScaleLabels()
         m_itemLabel3->setVisible( false );
     }
 
-    if ( spd4 >= 0.0f && spd4 <= 10000.0f )
+    if ( spd4 >= 0.0 && spd4 <= 10000.0 )
     {
         m_itemLabel4->setVisible( true );
         m_itemLabel4->setPlainText( QString("%1").arg(spd4, 3, 'f', 0, QChar(' ')) );
@@ -1635,7 +1635,7 @@ void qfi_PFD::ASI::updateScaleLabels()
         m_itemLabel4->setVisible( false );
     }
 
-    if ( spd5 >= 0.0f && spd5 <= 10000.0f )
+    if ( spd5 >= 0.0 && spd5 <= 10000.0 )
     {
         m_itemLabel5->setVisible( true );
         m_itemLabel5->setPlainText( QString("%1").arg(spd5, 3, 'f', 0, QChar(' ')) );
@@ -1645,7 +1645,7 @@ void qfi_PFD::ASI::updateScaleLabels()
         m_itemLabel5->setVisible( false );
     }
 
-    if ( spd6 >= 0.0f && spd6 <= 10000.0f )
+    if ( spd6 >= 0.0 && spd6 <= 10000.0 )
     {
         m_itemLabel6->setVisible( true );
         m_itemLabel6->setPlainText( QString("%1").arg(spd6, 3, 'f', 0, QChar(' ')) );
@@ -1655,7 +1655,7 @@ void qfi_PFD::ASI::updateScaleLabels()
         m_itemLabel6->setVisible( false );
     }
 
-    if ( spd7 >= 0.0f && spd7 <= 10000.0f )
+    if ( spd7 >= 0.0 && spd7 <= 10000.0 )
     {
         m_itemLabel7->setVisible( true );
         m_itemLabel7->setPlainText( QString("%1").arg(spd7, 3, 'f', 0, QChar(' ')) );
@@ -1680,16 +1680,16 @@ qfi_PFD::HSI::HSI( QGraphicsScene * scene ) :
 
     m_frameTextColor ( 255, 255, 255 ),
 
-    m_heading  ( 0.0f ),
+    m_heading  ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalHsiCtr       ( 150.0f , 345.0f ),
-    m_originalBackPos      (  60.0f,  240.0f ),
-    m_originalFacePos      (  45.0f , 240.0f ),
-    m_originalMarksPos     ( 134.0f , 219.0f ),
-    m_originalFrameTextCtr ( 149.5f , 227.5f ),
+    m_originalHsiCtr       ( 150.0 , 345.0 ),
+    m_originalBackPos      (  60.0,  240.0 ),
+    m_originalFacePos      (  45.0 , 240.0 ),
+    m_originalMarksPos     ( 134.0 , 219.0 ),
+    m_originalFrameTextCtr ( 149.5 , 227.5 ),
 
     m_backZ      (  80 ),
     m_faceZ      (  90 ),
@@ -1742,8 +1742,8 @@ void qfi_PFD::HSI::init( double scaleX, double scaleY )
     m_itemFrameText->setDefaultTextColor( m_frameTextColor );
     m_itemFrameText->setFont( m_frameTextFont );
     m_itemFrameText->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemFrameText->moveBy( m_scaleX * ( m_originalFrameTextCtr.x() - m_itemFrameText->boundingRect().width()  / 2.0f ),
-                            m_scaleY * ( m_originalFrameTextCtr.y() - m_itemFrameText->boundingRect().height() / 2.0f ) );
+    m_itemFrameText->moveBy( m_scaleX * ( m_originalFrameTextCtr.x() - m_itemFrameText->boundingRect().width()  / 2.0 ),
+                            m_scaleY * ( m_originalFrameTextCtr.y() - m_itemFrameText->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemFrameText );
 
     update( scaleX, scaleY );
@@ -1765,14 +1765,14 @@ void qfi_PFD::HSI::setHeading( double heading )
 {
     m_heading = heading;
 
-    while ( m_heading < 0.0f )
+    while ( m_heading < 0.0 )
     {
-        m_heading += 360.0f;
+        m_heading += 360.0;
     }
 
-    while ( m_heading > 360.0f )
+    while ( m_heading > 360.0 )
     {
-        m_heading -= 360.0f;
+        m_heading -= 360.0;
     }
 }
 
@@ -1785,7 +1785,7 @@ void qfi_PFD::HSI::reset()
     m_itemMarks     = 0;
     m_itemFrameText = 0;
 
-    m_heading  = 0.0f;
+    m_heading  = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1794,7 +1794,7 @@ void qfi_PFD::HSI::updateHeading()
 {
     m_itemFace->setRotation( - m_heading );
 
-    double fHeading = floor( m_heading + 0.5f );
+    double fHeading = floor( m_heading + 0.5 );
 
     m_itemFrameText->setPlainText( QString("%1").arg(fHeading, 3, 'f', 0, QChar('0')) );
 }
@@ -1809,21 +1809,21 @@ qfi_PFD::VSI::VSI( QGraphicsScene * scene ) :
     m_itemScale ( 0 ),
     m_itemArrow ( 0 ),
 
-    m_climbRate ( 0.0f ),
+    m_climbRate ( 0.0 ),
 
-    m_arrowDeltaY_new ( 0.0f ),
-    m_arrowDeltaY_old ( 0.0f ),
+    m_arrowDeltaY_new ( 0.0 ),
+    m_arrowDeltaY_old ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalMarkeHeight ( 75.0f ),
-    m_originalPixPerSpd1  ( 30.0f ),
-    m_originalPixPerSpd2  ( 20.0f ),
-    m_originalPixPerSpd4  (  5.0f ),
+    m_originalMarkeHeight ( 75.0 ),
+    m_originalPixPerSpd1  ( 30.0 ),
+    m_originalPixPerSpd2  ( 20.0 ),
+    m_originalPixPerSpd4  (  5.0 ),
 
-    m_originalScalePos ( 275.0f ,  50.0f ),
-    m_originalArrowPos ( 284.0f , 124.0f ),
+    m_originalScalePos ( 275.0 ,  50.0 ),
+    m_originalArrowPos ( 284.0 , 124.0 ),
 
     m_scaleZ  ( 70 ),
     m_arrowZ  ( 80 )
@@ -1875,8 +1875,8 @@ void qfi_PFD::VSI::setClimbRate( double climbRate )
 {
     m_climbRate = climbRate;
 
-    if      ( m_climbRate >  6.3f ) m_climbRate =  6.3f;
-    else if ( m_climbRate < -6.3f ) m_climbRate = -6.3f;
+    if      ( m_climbRate >  6.3 ) m_climbRate =  6.3;
+    else if ( m_climbRate < -6.3 ) m_climbRate = -6.3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1888,8 +1888,8 @@ void qfi_PFD::VSI::reset()
 
     m_climbRate = 0.0;
 
-    m_arrowDeltaY_new = 0.0f;
-    m_arrowDeltaY_old = 0.0f;
+    m_arrowDeltaY_new = 0.0;
+    m_arrowDeltaY_old = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1899,24 +1899,24 @@ void qfi_PFD::VSI::updateVSI()
     double climbRateAbs = fabs( m_climbRate );
     double arrowDeltaY = 0.0;
 
-    if ( climbRateAbs <= 1.0f )
+    if ( climbRateAbs <= 1.0 )
     {
         arrowDeltaY = m_originalPixPerSpd1 * climbRateAbs;
     }
-    else if ( climbRateAbs <= 2.0f )
+    else if ( climbRateAbs <= 2.0 )
     {
-        arrowDeltaY = m_originalPixPerSpd1 + m_originalPixPerSpd2 * ( climbRateAbs - 1.0f );
+        arrowDeltaY = m_originalPixPerSpd1 + m_originalPixPerSpd2 * ( climbRateAbs - 1.0 );
     }
     else
     {
-        arrowDeltaY = m_originalPixPerSpd1 + m_originalPixPerSpd2 + m_originalPixPerSpd4 * ( climbRateAbs - 2.0f );
+        arrowDeltaY = m_originalPixPerSpd1 + m_originalPixPerSpd2 + m_originalPixPerSpd4 * ( climbRateAbs - 2.0 );
     }
 
-    if ( m_climbRate < 0.0f ) arrowDeltaY *= -1.0f;
+    if ( m_climbRate < 0.0 ) arrowDeltaY *= -1.0;
 
     m_arrowDeltaY_new = m_scaleY * arrowDeltaY;
 
-    m_itemArrow->moveBy( 0.0f, m_arrowDeltaY_old - m_arrowDeltaY_new );
+    m_itemArrow->moveBy( 0.0, m_arrowDeltaY_old - m_arrowDeltaY_new );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1927,17 +1927,17 @@ qfi_PFD::ILS::ILS( QGraphicsScene *scene ) :
     m_itemIdentText ( 0 ),
     m_itemDistText  ( 0 ),
 
-    m_distance ( 0.0f ),
+    m_distance ( 0.0 ),
     m_identifier ( "" ),
 
     m_Dist_Visible ( false ),
     m_Ident_Visible ( false ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
-    m_originalIdentPos (  20.0f , 265.0f ),
-    m_originalDistPos  (  20.0f , 285.0f ),
+    m_originalIdentPos (  20.0 , 265.0 ),
+    m_originalDistPos  (  20.0 , 285.0 ),
 
     m_identZ  ( 120 ),
     m_distZ   ( 120 ),
@@ -2017,8 +2017,8 @@ void qfi_PFD::ILS::init( double scaleX, double scaleY )
     m_itemIdentText->setDefaultTextColor( m_textColor );
     m_itemIdentText->setFont( m_identFont );
     m_itemIdentText->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemIdentText->moveBy( m_scaleX * ( m_originalIdentPos.x() - m_itemIdentText->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalIdentPos.y() - m_itemIdentText->boundingRect().height() / 2.0f ) );
+    m_itemIdentText->moveBy( m_scaleX * ( m_originalIdentPos.x() - m_itemIdentText->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalIdentPos.y() - m_itemIdentText->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemIdentText );
 
     m_itemDistText = new QGraphicsTextItem( QString( "999" ) );
@@ -2027,8 +2027,8 @@ void qfi_PFD::ILS::init( double scaleX, double scaleY )
     m_itemDistText->setDefaultTextColor( m_textColor );
     m_itemDistText->setFont( m_distFont );
     m_itemDistText->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
-    m_itemDistText->moveBy( m_scaleX * ( m_originalDistPos.x() - m_itemDistText->boundingRect().width()  / 2.0f ),
-                         m_scaleY * ( m_originalDistPos.y() - m_itemDistText->boundingRect().height() / 2.0f ) );
+    m_itemDistText->moveBy( m_scaleX * ( m_originalDistPos.x() - m_itemDistText->boundingRect().width()  / 2.0 ),
+                         m_scaleY * ( m_originalDistPos.y() - m_itemDistText->boundingRect().height() / 2.0 ) );
     m_scene->addItem( m_itemDistText );
 
     update( scaleX, scaleY );

--- a/src/qfi_PFD.cpp
+++ b/src/qfi_PFD.cpp
@@ -52,10 +52,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 #include <stdio.h>
 
@@ -165,8 +161,8 @@ void qfi_PFD::resizeEvent( QResizeEvent * pEvent )
 
 void qfi_PFD::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     m_adi->init( m_scaleX, m_scaleY );
     m_alt->init( m_scaleX, m_scaleY );
@@ -204,8 +200,8 @@ void qfi_PFD::reset()
 
 void qfi_PFD::updateView()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     m_adi->update( m_scaleX, m_scaleY );
     m_alt->update( m_scaleX, m_scaleY );
@@ -330,7 +326,7 @@ qfi_PFD::ADI::ADI( QGraphicsScene * scene ) :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::init( float scaleX, float scaleY )
+void qfi_PFD::ADI::init( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -443,17 +439,17 @@ void qfi_PFD::ADI::init( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::update( float scaleX, float scaleY )
+void qfi_PFD::ADI::update( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
 
-    float delta  = m_originalPixPerDeg * m_pitch;
+    double delta  = m_originalPixPerDeg * m_pitch;
 
-    float roll_rad = M_PI * m_roll / 180.0f;
+    double roll_rad = M_PI * m_roll / 180.0f;
 
-    float sinRoll = sin( roll_rad );
-    float cosRoll = cos( roll_rad );
+    double sinRoll = sin( roll_rad );
+    double cosRoll = cos( roll_rad );
 
     updateLadd( delta, sinRoll, cosRoll );
     updateLaddBack( delta, sinRoll, cosRoll );
@@ -483,7 +479,7 @@ void qfi_PFD::ADI::update( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setRoll( float roll )
+void qfi_PFD::ADI::setRoll( double roll )
 {
     m_roll = roll;
 
@@ -493,7 +489,7 @@ void qfi_PFD::ADI::setRoll( float roll )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setPitch( float pitch )
+void qfi_PFD::ADI::setPitch( double pitch )
 {
     m_pitch = pitch;
 
@@ -503,7 +499,7 @@ void qfi_PFD::ADI::setPitch( float pitch )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setFlightPathMarker( float aoa, float sideslip, bool visible )
+void qfi_PFD::ADI::setFlightPathMarker( double aoa, double sideslip, bool visible )
 {
     m_angleOfAttack = aoa;
     m_sideslipAngle = sideslip;
@@ -537,7 +533,7 @@ void qfi_PFD::ADI::setFlightPathMarker( float aoa, float sideslip, bool visible 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setSlipSkid( float slipSkid )
+void qfi_PFD::ADI::setSlipSkid( double slipSkid )
 {
     m_slipSkid = slipSkid;
 
@@ -547,7 +543,7 @@ void qfi_PFD::ADI::setSlipSkid( float slipSkid )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setTurnRate( float turnRate )
+void qfi_PFD::ADI::setTurnRate( double turnRate )
 {
     m_turnRate = turnRate;
 
@@ -557,7 +553,7 @@ void qfi_PFD::ADI::setTurnRate( float turnRate )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setBarH( float barH, bool visible )
+void qfi_PFD::ADI::setBarH( double barH, bool visible )
 {
     m_barH = barH;
 
@@ -569,7 +565,7 @@ void qfi_PFD::ADI::setBarH( float barH, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setBarV( float barV, bool visible )
+void qfi_PFD::ADI::setBarV( double barV, bool visible )
 {
     m_barV = barV;
 
@@ -581,7 +577,7 @@ void qfi_PFD::ADI::setBarV( float barV, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setDotH( float dotH, bool visible )
+void qfi_PFD::ADI::setDotH( double dotH, bool visible )
 {
     m_dotH = dotH;
 
@@ -593,7 +589,7 @@ void qfi_PFD::ADI::setDotH( float dotH, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::setDotV( float dotV, bool visible )
+void qfi_PFD::ADI::setDotV( double dotV, bool visible )
 {
     m_dotV = dotV;
 
@@ -675,7 +671,7 @@ void qfi_PFD::ADI::reset()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::updateLadd( float delta, float sinRoll, float cosRoll )
+void qfi_PFD::ADI::updateLadd( double delta, double sinRoll, double cosRoll )
 {
     m_itemLadd->setRotation( - m_roll );
 
@@ -687,11 +683,11 @@ void qfi_PFD::ADI::updateLadd( float delta, float sinRoll, float cosRoll )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::updateLaddBack( float delta, float sinRoll, float cosRoll )
+void qfi_PFD::ADI::updateLaddBack( double delta, double sinRoll, double cosRoll )
 {
     m_itemBack->setRotation( - m_roll );
 
-    float deltaLaddBack = 0.0;
+    double deltaLaddBack = 0.0;
 
     if ( delta > m_deltaLaddBack_max )
     {
@@ -721,11 +717,11 @@ void qfi_PFD::ADI::updateRoll()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ADI::updateSlipSkid( float sinRoll, float cosRoll )
+void qfi_PFD::ADI::updateSlipSkid( double sinRoll, double cosRoll )
 {
     m_itemSlip->setRotation( - m_roll );
 
-    float deltaSlip = m_maxSlipDeflection * m_slipSkid;
+    double deltaSlip = m_maxSlipDeflection * m_slipSkid;
 
     m_slipDeltaX_new =  m_scaleX * deltaSlip * cosRoll;
     m_slipDeltaY_new = -m_scaleY * deltaSlip * sinRoll;
@@ -943,7 +939,7 @@ qfi_PFD::ALT::ALT( QGraphicsScene * scene ) :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ALT::init( float scaleX, float scaleY )
+void qfi_PFD::ALT::init( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1040,7 +1036,7 @@ void qfi_PFD::ALT::init( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ALT::update( float scaleX, float scaleY )
+void qfi_PFD::ALT::update( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1057,7 +1053,7 @@ void qfi_PFD::ALT::update( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ALT::setAltitude( float altitude )
+void qfi_PFD::ALT::setAltitude( double altitude )
 {
     m_altitude = altitude;
 
@@ -1067,7 +1063,7 @@ void qfi_PFD::ALT::setAltitude( float altitude )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ALT::setPressure( float pressure, int pressureUnit )
+void qfi_PFD::ALT::setPressure( double pressure, int pressureUnit )
 {
     m_pressure = pressure;
 
@@ -1146,8 +1142,8 @@ void qfi_PFD::ALT::updateScale()
     m_scale2DeltaY_new = m_scale1DeltaY_new;
     m_groundDeltaY_new = m_scale1DeltaY_new;
 
-    float scaleSingleHeight = m_scaleY * m_originalScaleHeight;
-    float scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0f;
+    double scaleSingleHeight = m_scaleY * m_originalScaleHeight;
+    double scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0f;
 
     while ( m_scale1DeltaY_new > scaleSingleHeight + m_scaleY * 74.5f )
     {
@@ -1173,9 +1169,9 @@ void qfi_PFD::ALT::updateScaleLabels()
     int tmp = floor( m_altitude + 0.5f );
     int alt = tmp - ( tmp % 500 );
 
-    float alt1 = (float)alt + 500.0f;
-    float alt2 = (float)alt;
-    float alt3 = (float)alt - 500.0f;
+    double alt1 = (double)alt + 500.0f;
+    double alt2 = (double)alt;
+    double alt3 = (double)alt - 500.0f;
 
     m_labelsDeltaY_new = m_scaleY * m_originalPixPerAlt * m_altitude;
 
@@ -1314,7 +1310,7 @@ qfi_PFD::ASI::ASI( QGraphicsScene * scene ) :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ASI::init( float scaleX, float scaleY )
+void qfi_PFD::ASI::init( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1446,7 +1442,7 @@ void qfi_PFD::ASI::init( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ASI::update( float scaleX, float scaleY )
+void qfi_PFD::ASI::update( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1460,7 +1456,7 @@ void qfi_PFD::ASI::update( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ASI::setAirspeed( float airspeed )
+void qfi_PFD::ASI::setAirspeed( double airspeed )
 {
     m_airspeed = airspeed;
 
@@ -1470,7 +1466,7 @@ void qfi_PFD::ASI::setAirspeed( float airspeed )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ASI::setMachNo( float machNo )
+void qfi_PFD::ASI::setMachNo( double machNo )
 {
     m_machNo = machNo;
 
@@ -1515,7 +1511,7 @@ void qfi_PFD::ASI::updateAirspeed()
 
     if ( m_machNo < 1.0f )
     {
-        float machNo = 1000.0f * m_machNo;
+        double machNo = 1000.0f * m_machNo;
         m_itemMachNo->setPlainText( QString(".%1").arg(machNo, 3, 'f', 0, QChar('0')) );
     }
     else
@@ -1541,8 +1537,8 @@ void qfi_PFD::ASI::updateScale()
     m_scale1DeltaY_new = m_scaleY * m_originalPixPerSpd * m_airspeed;
     m_scale2DeltaY_new = m_scale1DeltaY_new;
 
-    float scaleSingleHeight = m_scaleY * m_originalScaleHeight;
-    float scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0f;
+    double scaleSingleHeight = m_scaleY * m_originalScaleHeight;
+    double scaleDoubleHeight = m_scaleY * m_originalScaleHeight * 2.0f;
 
     while ( m_scale1DeltaY_new > scaleSingleHeight + m_scaleY * 74.5f )
     {
@@ -1567,13 +1563,13 @@ void qfi_PFD::ASI::updateScaleLabels()
     int tmp = floor( m_airspeed + 0.5f );
     int spd = tmp - ( tmp % 20 );
 
-    float spd1 = (float)spd + 60.0f;
-    float spd2 = (float)spd + 40.0f;
-    float spd3 = (float)spd + 20.0f;
-    float spd4 = (float)spd;
-    float spd5 = (float)spd - 20.0f;
-    float spd6 = (float)spd - 40.0f;
-    float spd7 = (float)spd - 60.0f;
+    double spd1 = (double)spd + 60.0f;
+    double spd2 = (double)spd + 40.0f;
+    double spd3 = (double)spd + 20.0f;
+    double spd4 = (double)spd;
+    double spd5 = (double)spd - 20.0f;
+    double spd6 = (double)spd - 40.0f;
+    double spd7 = (double)spd - 60.0f;
 
     while ( m_labelsDeltaY_new > m_scaleY * 15.0f )
     {
@@ -1710,7 +1706,7 @@ qfi_PFD::HSI::HSI( QGraphicsScene * scene ) :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::HSI::init( float scaleX, float scaleY )
+void qfi_PFD::HSI::init( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1755,7 +1751,7 @@ void qfi_PFD::HSI::init( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::HSI::update( float scaleX, float scaleY )
+void qfi_PFD::HSI::update( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1765,7 +1761,7 @@ void qfi_PFD::HSI::update( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::HSI::setHeading( float heading )
+void qfi_PFD::HSI::setHeading( double heading )
 {
     m_heading = heading;
 
@@ -1798,7 +1794,7 @@ void qfi_PFD::HSI::updateHeading()
 {
     m_itemFace->setRotation( - m_heading );
 
-    float fHeading = floor( m_heading + 0.5f );
+    double fHeading = floor( m_heading + 0.5f );
 
     m_itemFrameText->setPlainText( QString("%1").arg(fHeading, 3, 'f', 0, QChar('0')) );
 }
@@ -1837,7 +1833,7 @@ qfi_PFD::VSI::VSI( QGraphicsScene * scene ) :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::VSI::init( float scaleX, float scaleY )
+void qfi_PFD::VSI::init( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1863,7 +1859,7 @@ void qfi_PFD::VSI::init( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::VSI::update( float scaleX, float scaleY )
+void qfi_PFD::VSI::update( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -1875,7 +1871,7 @@ void qfi_PFD::VSI::update( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::VSI::setClimbRate( float climbRate )
+void qfi_PFD::VSI::setClimbRate( double climbRate )
 {
     m_climbRate = climbRate;
 
@@ -1900,8 +1896,8 @@ void qfi_PFD::VSI::reset()
 
 void qfi_PFD::VSI::updateVSI()
 {
-    float climbRateAbs = fabs( m_climbRate );
-    float arrowDeltaY = 0.0;
+    double climbRateAbs = fabs( m_climbRate );
+    double arrowDeltaY = 0.0;
 
     if ( climbRateAbs <= 1.0f )
     {
@@ -1990,7 +1986,7 @@ void qfi_PFD::ILS::setIdentifier( const QString &ident, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ILS::setDistance( float dist, bool visible )
+void qfi_PFD::ILS::setDistance( double dist, bool visible )
 {
     m_distance = dist;
     m_itemDistText->setVisible( visible );
@@ -1998,7 +1994,7 @@ void qfi_PFD::ILS::setDistance( float dist, bool visible )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ILS::update( float scaleX, float scaleY )
+void qfi_PFD::ILS::update( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;
@@ -2008,7 +2004,7 @@ void qfi_PFD::ILS::update( float scaleX, float scaleY )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_PFD::ILS::init( float scaleX, float scaleY )
+void qfi_PFD::ILS::init( double scaleX, double scaleY )
 {
     m_scaleX = scaleX;
     m_scaleY = scaleY;

--- a/src/qfi_PFD.cpp
+++ b/src/qfi_PFD.cpp
@@ -161,8 +161,8 @@ void qfi_PFD::resizeEvent( QResizeEvent * pEvent )
 
 void qfi_PFD::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     m_adi->init( m_scaleX, m_scaleY );
     m_alt->init( m_scaleX, m_scaleY );
@@ -200,8 +200,8 @@ void qfi_PFD::reset()
 
 void qfi_PFD::updateView()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     m_adi->update( m_scaleX, m_scaleY );
     m_alt->update( m_scaleX, m_scaleY );
@@ -1169,9 +1169,9 @@ void qfi_PFD::ALT::updateScaleLabels()
     int tmp = floor( m_altitude + 0.5f );
     int alt = tmp - ( tmp % 500 );
 
-    double alt1 = (double)alt + 500.0f;
-    double alt2 = (double)alt;
-    double alt3 = (double)alt - 500.0f;
+    double alt1 = static_cast<double>(alt) + 500.0f;
+    double alt2 = static_cast<double>(alt);
+    double alt3 = static_cast<double>(alt) - 500.0f;
 
     m_labelsDeltaY_new = m_scaleY * m_originalPixPerAlt * m_altitude;
 
@@ -1563,13 +1563,13 @@ void qfi_PFD::ASI::updateScaleLabels()
     int tmp = floor( m_airspeed + 0.5f );
     int spd = tmp - ( tmp % 20 );
 
-    double spd1 = (double)spd + 60.0f;
-    double spd2 = (double)spd + 40.0f;
-    double spd3 = (double)spd + 20.0f;
-    double spd4 = (double)spd;
-    double spd5 = (double)spd - 20.0f;
-    double spd6 = (double)spd - 40.0f;
-    double spd7 = (double)spd - 60.0f;
+    double spd1 = static_cast<double>(spd) + 60.0f;
+    double spd2 = static_cast<double>(spd) + 40.0f;
+    double spd3 = static_cast<double>(spd) + 20.0f;
+    double spd4 = static_cast<double>(spd);
+    double spd5 = static_cast<double>(spd) - 20.0f;
+    double spd6 = static_cast<double>(spd) - 40.0f;
+    double spd7 = static_cast<double>(spd) - 60.0f;
 
     while ( m_labelsDeltaY_new > m_scaleY * 15.0f )
     {

--- a/src/qfi_PFD.h
+++ b/src/qfi_PFD.h
@@ -84,13 +84,13 @@ public:
     void update();
 
     /** @param roll angle [deg] */
-    inline void setRoll( float roll )
+    inline void setRoll( double roll )
     {
         m_adi->setRoll( roll );
     }
 
     /** @param pitch angle [deg] */
-    inline void setPitch( float pitch )
+    inline void setPitch( double pitch )
     {
         m_adi->setPitch( pitch );
     }
@@ -99,13 +99,13 @@ public:
      * @param angle of attack [deg]
      * @param angle of sideslip [deg]
      * @param flight path marker visibility */
-    inline void setFlightPathMarker( float aoa, float sideslip, bool visible = true )
+    inline void setFlightPathMarker( double aoa, double sideslip, bool visible = true )
     {
         m_adi->setFlightPathMarker( aoa, sideslip, visible );
     }
 
     /** @param normalized slip or skid (range from -1.0 to 1.0) */
-    inline void setSlipSkid( float slipSkid )
+    inline void setSlipSkid( double slipSkid )
     {
         m_adi->setSlipSkid( slipSkid );
     }
@@ -113,7 +113,7 @@ public:
     /**
      * @param normalized turn rate (range from -1.0 to 1.0),
      * hash marks positions are set to be -0.5 and 0.5 */
-    inline void setTurnRate( float turnRate )
+    inline void setTurnRate( double turnRate )
     {
         m_adi->setTurnRate( turnRate );
     }
@@ -121,7 +121,7 @@ public:
     /**
      * @param normalized horizontal deviation bar position (range from -1.0 to 1.0)
      * @param horizontal deviation bar visibility */
-    inline void setBarH( float barH, bool visible = true )
+    inline void setBarH( double barH, bool visible = true )
     {
         m_adi->setBarH( barH, visible );
     }
@@ -129,7 +129,7 @@ public:
     /**
      * @param normalized vertical deviation bar position (range from -1.0 to 1.0)
      * @param vertical deviation bar visibility */
-    inline void setBarV( float barV, bool visible = true )
+    inline void setBarV( double barV, bool visible = true )
     {
         m_adi->setBarV( barV, visible );
     }
@@ -137,7 +137,7 @@ public:
     /**
      * @param normalized horizontal deviation dot position (range from -1.0 to 1.0)
      * @param horizontal deviation dot visibility */
-    inline void setDotH( float dotH, bool visible = true )
+    inline void setDotH( double dotH, bool visible = true )
     {
         m_adi->setDotH( dotH, visible );
     }
@@ -145,13 +145,13 @@ public:
     /**
      * @param normalized vertical deviation dot position (range from -1.0 to 1.0)
      * @param vertical deviation dot visibility */
-    inline void setDotV( float dotV, bool visible = true )
+    inline void setDotV( double dotV, bool visible = true )
     {
         m_adi->setDotV( dotV, visible );
     }
 
     /** @param altitude (dimensionless numeric value) */
-    inline void setAltitude( float altitude )
+    inline void setAltitude( double altitude )
     {
         m_alt->setAltitude( altitude );
     }
@@ -159,31 +159,31 @@ public:
     /**
      * @param pressure (dimensionless numeric value)
      * @param pressure unit according to GraphicsPFD::PressureUnit */
-    inline void setPressure( float pressure, PressureUnit pressureUnit )
+    inline void setPressure( double pressure, PressureUnit pressureUnit )
     {
         m_alt->setPressure( pressure, pressureUnit );
     }
 
     /** @param airspeed (dimensionless numeric value) */
-    inline void setAirspeed( float airspeed )
+    inline void setAirspeed( double airspeed )
     {
         m_asi->setAirspeed( airspeed );
     }
 
     /** @param Mach number */
-    inline void setMachNo( float machNo )
+    inline void setMachNo( double machNo )
     {
         m_asi->setMachNo( machNo );
     }
 
     /** @param heading [deg] */
-    inline void setHeading( float heading )
+    inline void setHeading( double heading )
     {
         m_hsi->setHeading( heading );
     }
 
     /** @param climb rate (dimensionless numeric value)  */
-    inline void setClimbRate( float climbRate )
+    inline void setClimbRate( double climbRate )
     {
         m_vsi->setClimbRate( climbRate );
     }
@@ -195,7 +195,7 @@ public:
     }
 
     /** @param distance [nautical miles] */
-    inline void setDistance( float dist, bool visible = false )
+    inline void setDistance( double dist, bool visible = false )
     {
         m_ils->setDistance( dist, visible );
     }
@@ -211,17 +211,17 @@ private:
     public:
 
         ADI( QGraphicsScene *scene );
-        void init( float scaleX, float scaleY );
-        void update( float scaleX, float scaleY );
-        void setRoll( float roll );
-        void setPitch( float pitch );
-        void setFlightPathMarker( float aoa, float sideslip, bool visible = true );
-        void setSlipSkid( float slipSkid );
-        void setTurnRate( float turnRate );
-        void setBarH( float barH, bool visible = true );
-        void setBarV( float barV, bool visible = true );
-        void setDotH( float dotH, bool visible = true );
-        void setDotV( float dotV, bool visible = true );
+        void init( double scaleX, double scaleY );
+        void update( double scaleX, double scaleY );
+        void setRoll( double roll );
+        void setPitch( double pitch );
+        void setFlightPathMarker( double aoa, double sideslip, bool visible = true );
+        void setSlipSkid( double slipSkid );
+        void setTurnRate( double turnRate );
+        void setBarH( double barH, bool visible = true );
+        void setBarV( double barV, bool visible = true );
+        void setDotH( double dotH, bool visible = true );
+        void setDotV( double dotV, bool visible = true );
 
     private:
 
@@ -242,16 +242,16 @@ private:
         QGraphicsSvgItem *m_itemScaleH;
         QGraphicsSvgItem *m_itemScaleV;
 
-        float m_roll;
-        float m_pitch;
-        float m_angleOfAttack;
-        float m_sideslipAngle;
-        float m_slipSkid;
-        float m_turnRate;
-        float m_barH;
-        float m_barV;
-        float m_dotH;
-        float m_dotV;
+        double m_roll;
+        double m_pitch;
+        double m_angleOfAttack;
+        double m_sideslipAngle;
+        double m_slipSkid;
+        double m_turnRate;
+        double m_barH;
+        double m_barV;
+        double m_dotH;
+        double m_dotV;
 
         bool m_pathValid;
 
@@ -261,47 +261,47 @@ private:
         bool m_dotHVisible;
         bool m_dotVVisible;
 
-        float m_laddDeltaX_new;
-        float m_laddDeltaX_old;
-        float m_laddBackDeltaX_new;
-        float m_laddBackDeltaX_old;
-        float m_laddBackDeltaY_new;
-        float m_laddBackDeltaY_old;
-        float m_laddDeltaY_new;
-        float m_laddDeltaY_old;
-        float m_slipDeltaX_new;
-        float m_slipDeltaX_old;
-        float m_slipDeltaY_new;
-        float m_slipDeltaY_old;
-        float m_turnDeltaX_new;
-        float m_turnDeltaX_old;
-        float m_pathDeltaX_new;
-        float m_pathDeltaX_old;
-        float m_pathDeltaY_new;
-        float m_pathDeltaY_old;
-        float m_markDeltaX_new;
-        float m_markDeltaX_old;
-        float m_markDeltaY_new;
-        float m_markDeltaY_old;
-        float m_barHDeltaX_new;
-        float m_barHDeltaX_old;
-        float m_barVDeltaY_new;
-        float m_barVDeltaY_old;
-        float m_dotHDeltaX_new;
-        float m_dotHDeltaX_old;
-        float m_dotVDeltaY_new;
-        float m_dotVDeltaY_old;
+        double m_laddDeltaX_new;
+        double m_laddDeltaX_old;
+        double m_laddBackDeltaX_new;
+        double m_laddBackDeltaX_old;
+        double m_laddBackDeltaY_new;
+        double m_laddBackDeltaY_old;
+        double m_laddDeltaY_new;
+        double m_laddDeltaY_old;
+        double m_slipDeltaX_new;
+        double m_slipDeltaX_old;
+        double m_slipDeltaY_new;
+        double m_slipDeltaY_old;
+        double m_turnDeltaX_new;
+        double m_turnDeltaX_old;
+        double m_pathDeltaX_new;
+        double m_pathDeltaX_old;
+        double m_pathDeltaY_new;
+        double m_pathDeltaY_old;
+        double m_markDeltaX_new;
+        double m_markDeltaX_old;
+        double m_markDeltaY_new;
+        double m_markDeltaY_old;
+        double m_barHDeltaX_new;
+        double m_barHDeltaX_old;
+        double m_barVDeltaY_new;
+        double m_barVDeltaY_old;
+        double m_dotHDeltaX_new;
+        double m_dotHDeltaX_old;
+        double m_dotVDeltaY_new;
+        double m_dotVDeltaY_old;
 
-        float m_scaleX;
-        float m_scaleY;
+        double m_scaleX;
+        double m_scaleY;
 
-        const float m_originalPixPerDeg;
-        const float m_deltaLaddBack_max;
-        const float m_deltaLaddBack_min;
-        const float m_maxSlipDeflection;
-        const float m_maxTurnDeflection;
-        const float m_maxBarsDeflection;
-        const float m_maxDotsDeflection;
+        const double m_originalPixPerDeg;
+        const double m_deltaLaddBack_max;
+        const double m_deltaLaddBack_min;
+        const double m_maxSlipDeflection;
+        const double m_maxTurnDeflection;
+        const double m_maxBarsDeflection;
+        const double m_maxDotsDeflection;
 
         QPointF m_originalAdiCtr;
         QPointF m_originalBackPos;
@@ -329,10 +329,10 @@ private:
         const int m_turnZ;
 
         void reset();
-        void updateLadd( float delta, float sinRoll, float cosRoll );
-        void updateLaddBack( float delta, float sinRoll, float cosRoll );
+        void updateLadd( double delta, double sinRoll, double cosRoll );
+        void updateLaddBack( double delta, double sinRoll, double cosRoll );
         void updateRoll();
-        void updateSlipSkid( float sinRoll, float cosRoll );
+        void updateSlipSkid( double sinRoll, double cosRoll );
         void updateTurnRate();
         void updateFlightPath();
         void updateBars();
@@ -344,10 +344,10 @@ private:
     public:
 
         ALT( QGraphicsScene *scene );
-        void init( float scaleX, float scaleY );
-        void update( float scaleX, float scaleY );
-        void setAltitude( float altitude );
-        void setPressure( float pressure, int pressureUnit );
+        void init( double scaleX, double scaleY );
+        void update( double scaleX, double scaleY );
+        void setAltitude( double altitude );
+        void setPressure( double pressure, int pressureUnit );
 
     private:
 
@@ -371,29 +371,29 @@ private:
         QFont  m_frameTextFont;
         QFont  m_labelsFont;
 
-        float m_altitude;
-        float m_pressure;
+        double m_altitude;
+        double m_pressure;
 
         int m_pressureUnit;
 
-        float m_scale1DeltaY_new;
-        float m_scale1DeltaY_old;
-        float m_scale2DeltaY_new;
-        float m_scale2DeltaY_old;
-        float m_groundDeltaY_new;
-        float m_groundDeltaY_old;
-        float m_labelsDeltaY_new;
-        float m_labelsDeltaY_old;
+        double m_scale1DeltaY_new;
+        double m_scale1DeltaY_old;
+        double m_scale2DeltaY_new;
+        double m_scale2DeltaY_old;
+        double m_groundDeltaY_new;
+        double m_groundDeltaY_old;
+        double m_labelsDeltaY_new;
+        double m_labelsDeltaY_old;
 
-        float m_scaleX;
-        float m_scaleY;
+        double m_scaleX;
+        double m_scaleY;
 
-        const float m_originalPixPerAlt;
-        const float m_originalScaleHeight;
-        const float m_originalLabelsX;
-        const float m_originalLabel1Y;
-        const float m_originalLabel2Y;
-        const float m_originalLabel3Y;
+        const double m_originalPixPerAlt;
+        const double m_originalScaleHeight;
+        const double m_originalLabelsX;
+        const double m_originalLabel1Y;
+        const double m_originalLabel2Y;
+        const double m_originalLabel3Y;
 
         QPointF m_originalBackPos;
         QPointF m_originalScale1Pos;
@@ -422,10 +422,10 @@ private:
     public:
 
         ASI( QGraphicsScene *scene );
-        void init( float scaleX, float scaleY );
-        void update( float scaleX, float scaleY );
-        void setAirspeed( float airspeed );
-        void setMachNo( float machNo );
+        void init( double scaleX, double scaleY );
+        void update( double scaleX, double scaleY );
+        void setAirspeed( double airspeed );
+        void setMachNo( double machNo );
 
     private:
 
@@ -451,29 +451,29 @@ private:
         QFont  m_frameTextFont;
         QFont  m_labelsFont;
 
-        float m_airspeed;
-        float m_machNo;
+        double m_airspeed;
+        double m_machNo;
 
-        float m_scale1DeltaY_new;
-        float m_scale1DeltaY_old;
-        float m_scale2DeltaY_new;
-        float m_scale2DeltaY_old;
-        float m_labelsDeltaY_new;
-        float m_labelsDeltaY_old;
+        double m_scale1DeltaY_new;
+        double m_scale1DeltaY_old;
+        double m_scale2DeltaY_new;
+        double m_scale2DeltaY_old;
+        double m_labelsDeltaY_new;
+        double m_labelsDeltaY_old;
 
-        float m_scaleX;
-        float m_scaleY;
+        double m_scaleX;
+        double m_scaleY;
 
-        const float m_originalPixPerSpd;
-        const float m_originalScaleHeight;
-        const float m_originalLabelsX;
-        const float m_originalLabel1Y;
-        const float m_originalLabel2Y;
-        const float m_originalLabel3Y;
-        const float m_originalLabel4Y;
-        const float m_originalLabel5Y;
-        const float m_originalLabel6Y;
-        const float m_originalLabel7Y;
+        const double m_originalPixPerSpd;
+        const double m_originalScaleHeight;
+        const double m_originalLabelsX;
+        const double m_originalLabel1Y;
+        const double m_originalLabel2Y;
+        const double m_originalLabel3Y;
+        const double m_originalLabel4Y;
+        const double m_originalLabel5Y;
+        const double m_originalLabel6Y;
+        const double m_originalLabel7Y;
 
         QPointF m_originalBackPos;
         QPointF m_originalScale1Pos;
@@ -499,9 +499,9 @@ private:
     public:
 
         HSI( QGraphicsScene *scene );
-        void init( float scaleX, float scaleY );
-        void update( float scaleX, float scaleY );
-        void setHeading( float heading );
+        void init( double scaleX, double scaleY );
+        void update( double scaleX, double scaleY );
+        void setHeading( double heading );
 
     private:
 
@@ -516,10 +516,10 @@ private:
 
         QFont  m_frameTextFont;
 
-        float m_heading;
+        double m_heading;
 
-        float m_scaleX;
-        float m_scaleY;
+        double m_scaleX;
+        double m_scaleY;
 
         QPointF m_originalHsiCtr;
         QPointF m_originalBackPos;
@@ -541,9 +541,9 @@ private:
     public:
 
         VSI( QGraphicsScene *scene );
-        void init( float scaleX, float scaleY );
-        void update( float scaleX, float scaleY );
-        void setClimbRate( float climbRate );
+        void init( double scaleX, double scaleY );
+        void update( double scaleX, double scaleY );
+        void setClimbRate( double climbRate );
 
     private:
 
@@ -552,18 +552,18 @@ private:
         QGraphicsSvgItem  *m_itemScale;
         QGraphicsSvgItem  *m_itemArrow;
 
-        float m_climbRate;
+        double m_climbRate;
 
-        float m_arrowDeltaY_new;
-        float m_arrowDeltaY_old;
+        double m_arrowDeltaY_new;
+        double m_arrowDeltaY_old;
 
-        float m_scaleX;
-        float m_scaleY;
+        double m_scaleX;
+        double m_scaleY;
 
-        const float m_originalMarkeHeight;
-        const float m_originalPixPerSpd1;
-        const float m_originalPixPerSpd2;
-        const float m_originalPixPerSpd4;
+        const double m_originalMarkeHeight;
+        const double m_originalPixPerSpd1;
+        const double m_originalPixPerSpd2;
+        const double m_originalPixPerSpd4;
 
         QPointF m_originalScalePos;
         QPointF m_originalArrowPos;
@@ -580,10 +580,10 @@ private:
     public:
 
         ILS( QGraphicsScene *scene );
-        void init( float scaleX, float scaleY );
-        void update( float scaleX, float scaleY );
+        void init( double scaleX, double scaleY );
+        void update( double scaleX, double scaleY );
         void setIdentifier( const QString &ident, bool visible );
-        void setDistance( float dist, bool visible );
+        void setDistance( double dist, bool visible );
 
     private:
 
@@ -592,14 +592,14 @@ private:
         QGraphicsTextItem *m_itemIdentText;
         QGraphicsTextItem *m_itemDistText;
 
-        float m_distance;
+        double m_distance;
         QString m_identifier;
 
         bool m_Dist_Visible;
         bool m_Ident_Visible;
 
-        float m_scaleX;
-        float m_scaleY;
+        double m_scaleX;
+        double m_scaleY;
 
         QPointF m_originalIdentPos;
         QPointF m_originalDistPos;
@@ -627,8 +627,8 @@ private:
     QGraphicsSvgItem *m_itemBack;
     QGraphicsSvgItem *m_itemMask;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;

--- a/src/qfi_TC.cpp
+++ b/src/qfi_TC.cpp
@@ -51,10 +51,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 
 #include "qfi_TC.h"
@@ -137,7 +133,7 @@ void qfi_TC::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_TC::setTurnRate( float turnRate )
+void qfi_TC::setTurnRate( double turnRate )
 {
     m_turnRate = turnRate;
 
@@ -147,7 +143,7 @@ void qfi_TC::setTurnRate( float turnRate )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_TC::setSlipSkid( float slipSkid )
+void qfi_TC::setSlipSkid( double slipSkid )
 {
     m_slipSkid = slipSkid;
 
@@ -170,8 +166,8 @@ void qfi_TC::resizeEvent( QResizeEvent *event )
 
 void qfi_TC::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     reset();
 
@@ -232,12 +228,12 @@ void qfi_TC::reset()
 
 void qfi_TC::updateView()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     m_itemBall->setRotation( -m_slipSkid );
 
-    float angle = ( m_turnRate / 3.0f ) * 20.0f;
+    double angle = ( m_turnRate / 3.0f ) * 20.0f;
 
     m_itemMark->setRotation( angle );
 

--- a/src/qfi_TC.cpp
+++ b/src/qfi_TC.cpp
@@ -166,8 +166,8 @@ void qfi_TC::resizeEvent( QResizeEvent *event )
 
 void qfi_TC::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     reset();
 
@@ -228,8 +228,8 @@ void qfi_TC::reset()
 
 void qfi_TC::updateView()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     m_itemBall->setRotation( -m_slipSkid );
 

--- a/src/qfi_TC.cpp
+++ b/src/qfi_TC.cpp
@@ -69,17 +69,17 @@ qfi_TC::qfi_TC( QWidget *parent ) :
     m_itemMark   ( 0 ),
     m_itemCase   ( 0 ),
 
-    m_turnRate ( 0.0f ),
-    m_slipSkid ( 0.0f ),
+    m_turnRate ( 0.0 ),
+    m_slipSkid ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 240 ),
     m_originalWidth  ( 240 ),
 
-    m_originalMarkCtr ( 120.0f , 120.0f ),
-    m_originalBallCtr ( 120.0f , -36.0f ),
+    m_originalMarkCtr ( 120.0 , 120.0 ),
+    m_originalBallCtr ( 120.0 , -36.0 ),
 
     m_backZ  ( -70 ),
     m_ballZ  ( -60 ),
@@ -137,8 +137,8 @@ void qfi_TC::setTurnRate( double turnRate )
 {
     m_turnRate = turnRate;
 
-    if ( m_turnRate < -6.0f ) m_turnRate = -6.0f;
-    if ( m_turnRate >  6.0f ) m_turnRate =  6.0f;
+    if ( m_turnRate < -6.0 ) m_turnRate = -6.0;
+    if ( m_turnRate >  6.0 ) m_turnRate =  6.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -147,8 +147,8 @@ void qfi_TC::setSlipSkid( double slipSkid )
 {
     m_slipSkid = slipSkid;
 
-    if ( m_slipSkid < -15.0f ) m_slipSkid = -15.0f;
-    if ( m_slipSkid >  15.0f ) m_slipSkid =  15.0f;
+    if ( m_slipSkid < -15.0 ) m_slipSkid = -15.0;
+    if ( m_slipSkid >  15.0 ) m_slipSkid =  15.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -209,7 +209,7 @@ void qfi_TC::init()
     m_itemCase->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemCase );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -220,8 +220,8 @@ void qfi_TC::reset()
 {
     m_itemCase = 0;
 
-    m_turnRate = 0.0f;
-    m_slipSkid = 0.0f;
+    m_turnRate = 0.0;
+    m_slipSkid = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -233,7 +233,7 @@ void qfi_TC::updateView()
 
     m_itemBall->setRotation( -m_slipSkid );
 
-    double angle = ( m_turnRate / 3.0f ) * 20.0f;
+    double angle = ( m_turnRate / 3.0 ) * 20.0;
 
     m_itemMark->setRotation( angle );
 

--- a/src/qfi_TC.h
+++ b/src/qfi_TC.h
@@ -75,10 +75,10 @@ public:
     void update();
 
     /** @param turn rate [deg/s] */
-    void setTurnRate( float turnRate );
+    void setTurnRate( double turnRate );
 
     /** @param slip/skid ball angle [deg] */
-    void setSlipSkid( float slipSkid );
+    void setSlipSkid( double slipSkid );
 
 protected:
 
@@ -95,11 +95,11 @@ private:
     QGraphicsSvgItem *m_itemMark;
     QGraphicsSvgItem *m_itemCase;
 
-    float m_turnRate;
-    float m_slipSkid;
+    double m_turnRate;
+    double m_slipSkid;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;

--- a/src/qfi_VSI.cpp
+++ b/src/qfi_VSI.cpp
@@ -51,10 +51,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef WIN32
-#   include <float.h>
-#endif
-
 #include <math.h>
 
 #include "qfi_VSI.h"
@@ -129,7 +125,7 @@ void qfi_VSI::update()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void qfi_VSI::setClimbRate( float climbRate )
+void qfi_VSI::setClimbRate( double climbRate )
 {
     m_climbRate = climbRate;
 
@@ -152,8 +148,8 @@ void qfi_VSI::resizeEvent( QResizeEvent *event )
 
 void qfi_VSI::init()
 {
-    m_scaleX = (float)width()  / (float)m_originalWidth;
-    m_scaleY = (float)height() / (float)m_originalHeight;
+    m_scaleX = (double)width()  / (double)m_originalWidth;
+    m_scaleY = (double)height() / (double)m_originalHeight;
 
     reset();
 

--- a/src/qfi_VSI.cpp
+++ b/src/qfi_VSI.cpp
@@ -66,15 +66,15 @@ qfi_VSI::qfi_VSI( QWidget *parent ) :
     m_itemHand ( 0 ),
     m_itemCase ( 0 ),
 
-    m_climbRate ( 0.0f ),
+    m_climbRate ( 0.0 ),
 
-    m_scaleX ( 1.0f ),
-    m_scaleY ( 1.0f ),
+    m_scaleX ( 1.0 ),
+    m_scaleY ( 1.0 ),
 
     m_originalHeight ( 240 ),
     m_originalWidth  ( 240 ),
 
-    m_originalVsiCtr ( 120.0f , 120.0f ),
+    m_originalVsiCtr ( 120.0 , 120.0 ),
 
     m_faceZ ( -20 ),
     m_handZ ( -10 ),
@@ -129,8 +129,8 @@ void qfi_VSI::setClimbRate( double climbRate )
 {
     m_climbRate = climbRate;
 
-    if ( m_climbRate < -2000.0f ) m_climbRate = -2000.0f;
-    if ( m_climbRate >  2000.0f ) m_climbRate =  2000.0f;
+    if ( m_climbRate < -2000.0 ) m_climbRate = -2000.0;
+    if ( m_climbRate >  2000.0 ) m_climbRate =  2000.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -172,7 +172,7 @@ void qfi_VSI::init()
     m_itemCase->setTransform( QTransform::fromScale( m_scaleX, m_scaleY ), true );
     m_scene->addItem( m_itemCase );
 
-    centerOn( width() / 2.0f , height() / 2.0f );
+    centerOn( width() / 2.0 , height() / 2.0 );
 
     updateView();
 }
@@ -185,14 +185,14 @@ void qfi_VSI::reset()
     m_itemHand = 0;
     m_itemCase = 0;
 
-    m_climbRate = 0.0f;
+    m_climbRate = 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void qfi_VSI::updateView()
 {
-    m_itemHand->setRotation( m_climbRate * 0.086f );
+    m_itemHand->setRotation( m_climbRate * 0.086 );
 
     m_scene->update();
 }

--- a/src/qfi_VSI.cpp
+++ b/src/qfi_VSI.cpp
@@ -148,8 +148,8 @@ void qfi_VSI::resizeEvent( QResizeEvent *event )
 
 void qfi_VSI::init()
 {
-    m_scaleX = (double)width()  / (double)m_originalWidth;
-    m_scaleY = (double)height() / (double)m_originalHeight;
+    m_scaleX = static_cast<double>(width())  / static_cast<double>(m_originalWidth);
+    m_scaleY = static_cast<double>(height()) / static_cast<double>(m_originalHeight);
 
     reset();
 

--- a/src/qfi_VSI.h
+++ b/src/qfi_VSI.h
@@ -75,7 +75,7 @@ public:
     void update();
 
     /** @param climb rate [ft/min] */
-    void setClimbRate( float climbRate );
+    void setClimbRate( double climbRate );
 
 protected:
 
@@ -89,10 +89,10 @@ private:
     QGraphicsSvgItem *m_itemHand;
     QGraphicsSvgItem *m_itemCase;
 
-    float m_climbRate;
+    double m_climbRate;
 
-    float m_scaleX;
-    float m_scaleY;
+    double m_scaleX;
+    double m_scaleY;
 
     const int m_originalHeight;
     const int m_originalWidth;


### PR DESCRIPTION
Hi,

thanks for moving this project to github! Working on the project with a language checker enabled in Qt Creator was almost impossible due to the endless warnings about floating point precision. I therefore moved to double, Qt is calculating in double anyways. It shouldn't be a problem on modern machines. I removed the float literals in that course.

I also eliminated C style casts ans replaced them with static casts.